### PR TITLE
Lint react component params

### DIFF
--- a/.yarn/patches/jest-resolve-npm-28.1.1-5f1937a1f8.patch
+++ b/.yarn/patches/jest-resolve-npm-28.1.1-5f1937a1f8.patch
@@ -1,0 +1,16 @@
+diff --git a/build/defaultResolver.js b/build/defaultResolver.js
+index a19986bc668969d793b194073e93ded46bc749e5..2927a26c6f0b460ab7604841dc91777639f668fc 100644
+--- a/build/defaultResolver.js
++++ b/build/defaultResolver.js
+@@ -56,6 +56,11 @@ const defaultResolver = (path, options) => {
+     return (0, _jestPnpResolver().default)(path, options);
+   }
+ 
++  // https://github.com/facebook/jest/issues/11604#issuecomment-866629115
++  if (path === 'pnpapi') {
++    return require.resolve('pnpapi', { paths: [options.basedir] });
++  }
++
+   const resolveOptions = {
+     ...options,
+     isDirectory: _fileWalkers.isDirectory,

--- a/package.json
+++ b/package.json
@@ -28,5 +28,9 @@
     "jest": "^28.1.2",
     "prettier": "^2.7.1",
     "typescript": "^4.7.4"
+  },
+  "resolutions": {
+    "jest-resolve": "patch:jest-resolve@npm:28.1.1#.yarn/patches/jest-resolve-npm-28.1.1-5f1937a1f8.patch",
+    "jest-resolve@28.1.1": "patch:jest-resolve@npm:28.1.1#.yarn/patches/jest-resolve-npm-28.1.1-5f1937a1f8.patch"
   }
 }

--- a/packages/eslint-plugin/.eslintrc.js
+++ b/packages/eslint-plugin/.eslintrc.js
@@ -4,6 +4,7 @@ module.exports = /** @type {import("eslint").Linter.Config} */ ({
     "node/no-unsupported-features/es-syntax": "off",
     "node/no-missing-import": "off",
   },
+  ignorePatterns: ["configs/fixtures/*.ts", "configs/fixtures/*.tsx"],
   overrides: [
     {
       files: ["**/*.ts", "**/*.tsx"],

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+- Add a new rule `@hi18n/react-component-params` https://github.com/wantedly/dx/issues/702
+  - This is not included in `plugin:@hi18n/recommended` because it requires type checking.
+- Added a new preset `plugin:@hi18n/recommended-requiring-type-checking`
+  - `@hi18n/react-component-params` is included in this preset.
 - Corner case bug fix on `new Book<this>()`
 
 ## 0.1.5

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -1,0 +1,29 @@
+## `@hi18n/eslint-plugin`
+
+This is a collection of ESLint rules to enforce correct and conventional uses
+of [hi18n](https://github.com/wantedly/hi18n), an internationalization library.
+
+It also contains rules internally used by `@hi18n/cli`.
+
+## Configuration example
+
+```
+npm install -D @hi18n/eslint-plugin
+# Or:
+yarn add -D @hi18n/eslint-plugin
+```
+
+And:
+
+```javascript
+// .eslintrc.js
+module.exports = {
+  extends: [
+    // ...
+    "plugin:@hi18n/recommended",
+    // Useful if TypeScript is configured in your project
+    "plugin:@hi18n/recommended-requiring-type-checking",
+  ],
+  // ...
+};
+```

--- a/packages/eslint-plugin/configs/fixtures/estree.tsx
+++ b/packages/eslint-plugin/configs/fixtures/estree.tsx
@@ -1,0 +1,1 @@
+// This dummy file is needed by TSESLint.RuleTester.

--- a/packages/eslint-plugin/configs/fixtures/tsconfig.json
+++ b/packages/eslint-plugin/configs/fixtures/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "esModuleInterop": true,
+    "jsx": "react-jsx"
+  }
+}

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -59,7 +59,13 @@
     "eslint-visitor-keys": "^3.3.0"
   },
   "peerDependencies": {
-    "eslint": "^7.0.0 || ^8.0.0"
+    "eslint": "^7.0.0 || ^8.0.0",
+    "typescript": "*"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@babel/cli": "^7.18.6",
@@ -68,10 +74,15 @@
     "@babel/plugin-transform-runtime": "^7.18.6",
     "@babel/preset-env": "^7.18.6",
     "@babel/preset-typescript": "^7.18.6",
+    "@hi18n/core": "workspace:*",
+    "@hi18n/react": "workspace:*",
+    "@hi18n/react-context": "workspace:*",
     "@jest/globals": "^28.1.2",
     "@types/babel__core": "^7.1.19",
     "@types/eslint": "^8.4.5",
     "@types/node": "^17.0.32",
+    "@types/react": "^18.0.14",
+    "@typescript-eslint/parser": "^5.30.4",
     "@typescript-eslint/types": "^5.30.4",
     "babel-jest": "^28.1.2",
     "babel-plugin-polyfill-corejs3": "^0.5.2",
@@ -81,6 +92,7 @@
     "espree": "^9.3.2",
     "jest": "^28.1.2",
     "prettier": "^2.7.1",
+    "react": "^18.2.0",
     "rimraf": "^3.0.2",
     "typescript": "^4.7.4"
   }

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -8,6 +8,7 @@ import * as ruleNoMissingTranslationIds from "./rules/no-missing-translation-ids
 import * as ruleNoMissingTranslationIdsInTypes from "./rules/no-missing-translation-ids-in-types";
 import * as ruleNoUnusedTranslationIds from "./rules/no-unused-translation-ids";
 import * as ruleNoUnusedTranslationIdsInTypes from "./rules/no-unused-translation-ids-in-types";
+import * as ruleReactComponentParams from "./rules/react-component-params";
 import * as ruleWellFormedBookDefinitions from "./rules/well-formed-book-definitions";
 import * as ruleWellFormedBookReferences from "./rules/well-formed-book-references";
 import * as ruleWellFormedCatalogDefinitions from "./rules/well-formed-catalog-definitions";
@@ -22,6 +23,11 @@ export const configs: Record<string, TSESLint.Linter.Config> = {
       "@hi18n/well-formed-catalog-definitions": "error",
     },
   },
+  "recommended-requiring-type-checking": {
+    rules: {
+      "@hi18n/react-component-params": "error",
+    },
+  },
 };
 
 export const rules = {
@@ -32,6 +38,7 @@ export const rules = {
   "no-dynamic-translation-ids": ruleNoDynamicTranslationIds,
   "no-missing-translation-ids": ruleNoMissingTranslationIds,
   "no-missing-translation-ids-in-types": ruleNoMissingTranslationIdsInTypes,
+  "react-component-params": ruleReactComponentParams,
   "well-formed-book-references": ruleWellFormedBookReferences,
   "well-formed-book-definitions": ruleWellFormedBookDefinitions,
   "well-formed-catalog-definitions": ruleWellFormedCatalogDefinitions,

--- a/packages/eslint-plugin/src/rules/react-component-params.test.ts
+++ b/packages/eslint-plugin/src/rules/react-component-params.test.ts
@@ -1,0 +1,106 @@
+import path from "node:path";
+import { TSESLint } from "@typescript-eslint/utils";
+import * as rule from "./react-component-params";
+
+new TSESLint.RuleTester({
+  parser: require.resolve("@typescript-eslint/parser"),
+  parserOptions: {
+    ecmaVersion: 2015,
+    sourceType: "module",
+    ecmaFeatures: { jsx: true },
+    project: "./tsconfig.json",
+    tsconfigRootDir: path.resolve(__dirname, "../../configs/fixtures"),
+  },
+}).run("@hi18n/react-component-params", rule, {
+  valid: [
+    `
+      import { Book, ComponentPlaceholder, Message } from "@hi18n/core";
+      import { Translate } from "@hi18n/react";
+
+      type Vocabulary = {
+        "example/link": Message<{ link: ComponentPlaceholder }>;
+      };
+
+      const book = new Book<Vocabulary>({});
+
+      <Translate book={book} id="example/link">
+        <a key="link" />
+      </Translate>
+    `,
+    `
+      import { Book, ComponentPlaceholder, Message } from "@hi18n/core";
+      import { Translate } from "@hi18n/react";
+
+      type Vocabulary = {
+        "example/link": Message<{ 0: ComponentPlaceholder }>;
+      };
+
+      const book = new Book<Vocabulary>({});
+
+      <Translate book={book} id="example/link">
+        <a />
+      </Translate>
+    `,
+  ],
+  invalid: [
+    {
+      code: `
+        import { Book, ComponentPlaceholder, Message } from "@hi18n/core";
+        import { Translate } from "@hi18n/react";
+
+        type Vocabulary = {
+          "example/link": Message<{ link: ComponentPlaceholder }>;
+        };
+
+        const book = new Book<Vocabulary>({});
+
+        <Translate book={book} id="example/link">
+        </Translate>
+      `,
+      errors: [
+        {
+          messageId: "missing-component-argument",
+          data: { paramNames: "link" },
+        },
+      ],
+    },
+    {
+      code: `
+        import { Book, ComponentPlaceholder, Message } from "@hi18n/core";
+        import { Translate } from "@hi18n/react";
+
+        type Vocabulary = {
+          "example/link": Message<{ link: ComponentPlaceholder }>;
+        };
+
+        const book = new Book<Vocabulary>({});
+
+        <Translate book={book} id="example/link">
+          <a key="link" />
+          <strong />
+        </Translate>
+      `,
+      errors: [{ messageId: "extra-component-argument", data: { argName: 0 } }],
+    },
+    {
+      code: `
+        import { Book, ComponentPlaceholder, Message } from "@hi18n/core";
+        import { Translate } from "@hi18n/react";
+
+        type Vocabulary = {
+          "example/link": Message<{ link: ComponentPlaceholder }>;
+        };
+
+        const book = new Book<Vocabulary>({});
+
+        <Translate book={book} id="example/link">
+          <a key="link" />
+          <strong key="strong" />
+        </Translate>
+      `,
+      errors: [
+        { messageId: "extra-component-argument", data: { argName: "strong" } },
+      ],
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/rules/react-component-params.ts
+++ b/packages/eslint-plugin/src/rules/react-component-params.ts
@@ -1,0 +1,286 @@
+import { ESLintUtils, TSESTree, type TSESLint } from "@typescript-eslint/utils";
+import * as ts from "typescript";
+import { translationCallTracker } from "../common-trackers";
+
+type MessageIds =
+  | "invalid-signature"
+  | "missing-component-argument"
+  | "extra-component-argument";
+
+export const meta: TSESLint.RuleMetaData<MessageIds> = {
+  type: "problem",
+  docs: {
+    description: "additional type checking for the <Translate> component",
+    recommended: "error",
+  },
+  messages: {
+    "invalid-signature": "Lint failed: invalid signature",
+    "missing-component-argument": "missing argument: {{ paramNames }}",
+    "extra-component-argument": "unknown component name: {{ argName }}",
+  },
+  schema: {},
+};
+
+export function create(
+  context: Readonly<TSESLint.RuleContext<MessageIds, []>>
+): TSESLint.RuleListener {
+  const tracker = translationCallTracker();
+  // For some reason we visit the node twice. It should ideally be unnecessary.
+  const visited: Set<TSESTree.Node> = new Set();
+  tracker.listen("translation", (node, captured) => {
+    const idNode = captured["id"]!;
+    if (idNode.type !== "Literal" || typeof idNode.value !== "string") {
+      return;
+    }
+    if (node.type !== "JSXElement") {
+      return;
+    }
+
+    if (visited.has(node)) return;
+    visited.add(node);
+
+    // Start querying tsc
+    const parserServices = ESLintUtils.getParserServices(context);
+    const checker = parserServices.program.getTypeChecker();
+    // <Translate> ... </Translate> or <Translate />
+    const tscElementNode = parserServices.esTreeNodeToTSNodeMap.get(node);
+    // <Translate> or <Translate />
+    const tscTagNode = getOpenTag(tscElementNode);
+
+    const expectedParamsResult = getExpectedComponentParams(
+      checker,
+      tscTagNode
+    );
+    if (!expectedParamsResult) {
+      context.report({
+        node,
+        messageId: "invalid-signature",
+      });
+      return;
+    }
+    const [expectedParams, expectedComponentParams] = expectedParamsResult;
+
+    console.log("expected = ", expectedParams);
+    console.log("expected (component only) = ", expectedComponentParams);
+
+    const argsFromProps = getComponentArgsFromProps(checker, tscTagNode);
+    console.log("args (props) = ", argsFromProps);
+
+    const argsFromChildren = getComponentArgsFromChildren(
+      checker,
+      tscElementNode
+    );
+    console.log(
+      "args (children) = ",
+      argsFromChildren.map(([key]) => key)
+    );
+
+    // Find missing params
+    const foundArgNames = new Set(
+      argsFromProps.concat(argsFromChildren.map(([key]) => key))
+    );
+    const missingParamNames: string[] = [];
+    for (const expectedParam of expectedComponentParams) {
+      if (!foundArgNames.has(expectedParam)) {
+        missingParamNames.push(expectedParam);
+      }
+    }
+    if (missingParamNames.length > 0) {
+      context.report({
+        node: parserServices.tsNodeToESTreeNodeMap.get(tscTagNode),
+        messageId: "missing-component-argument",
+        data: {
+          paramNames: missingParamNames.join(", "),
+        },
+      });
+    }
+
+    // Find extra args
+    const expectedParamsSet = new Set(expectedParams);
+    for (const [argName, argNode] of argsFromChildren) {
+      if (!expectedParamsSet.has(argName)) {
+        context.report({
+          node: parserServices.tsNodeToESTreeNodeMap.get(argNode),
+          messageId: "extra-component-argument",
+          data: {
+            argName,
+          },
+        });
+      }
+    }
+  });
+  return {
+    ImportDeclaration(node) {
+      tracker.trackImport(context.getSourceCode().scopeManager!, node);
+    },
+  };
+}
+
+function getExpectedComponentParams(
+  checker: ts.TypeChecker,
+  tscTagNode: ts.JsxOpeningLikeElement
+): [string[], string[]] | undefined {
+  // Reference to the Translate component (with its resolved type arguments)
+  const sig = checker.getResolvedSignature(tscTagNode);
+  if (!sig) {
+    return undefined;
+  }
+
+  if (sig.parameters.length < 1) {
+    return undefined;
+  }
+
+  // The Translate component's first argument (= props argument)
+  // It is TranslateProps<Vocabulary, Id>
+  const propsType = checker.getTypeOfSymbolAtLocation(
+    sig.parameters[0]!,
+    tscTagNode
+  );
+
+  // Get MessageArguments<Vocabulary[Id], React.ReactElement>
+  const messageParamsType = getRealMessageParamsFromProps(checker, propsType);
+  if (!messageParamsType) {
+    return undefined;
+  }
+
+  const messageParams = checker.getPropertiesOfType(messageParamsType);
+  const componentParams: string[] = [];
+  for (const sym of messageParams) {
+    const paramType = checker.getTypeOfSymbolAtLocation(sym, tscTagNode);
+    if (extractTypeAlias(paramType, "ReactElement", 0)) {
+      componentParams.push(sym.getName());
+    }
+  }
+  return [messageParams.map((sym) => sym.getName()), componentParams];
+}
+
+// TranslateProps<Vocabulary, Id> -> MessageArguments<Vocabulary[Id], React.ReactElement>
+function getRealMessageParamsFromProps(
+  checker: ts.TypeChecker,
+  ty: ts.Type
+): ts.Type | undefined {
+  // Check if it is TranslateProps<Vocabulary, Id>
+  if (!extractTypeAlias(ty, "TranslateProps", 2)) return undefined;
+
+  // TranslateProps expands to intersection
+  if (!ty.isIntersection()) return undefined;
+
+  for (const elem of ty.types) {
+    // Either BaseTranslateProps<Vocabulary, Id>,
+    //   Partial<MessageArguments<Vocabulary[Id], React.ReactElement>>,
+    //   or Omit<MessageArguments<Vocabulary[Id], React.ReactElement>, ...>,
+
+    // If it is Partial<T>, return T inside
+    const partialParams = extractTypeAlias(elem, "Partial", 1);
+    if (!partialParams) continue;
+
+    return partialParams[0]!;
+  }
+  return undefined;
+}
+
+function getComponentArgsFromProps(
+  checker: ts.TypeChecker,
+  tscTagNode: ts.JsxOpeningLikeElement
+): string[] {
+  const args: string[] = [];
+  for (const prop of tscTagNode.attributes.properties) {
+    if (ts.isJsxAttribute(prop)) {
+      args.push(prop.name.text);
+    } else if (ts.isJsxSpreadAttribute(prop)) {
+      const attrTypes = checker.getTypeAtLocation(prop.expression);
+      for (const subpropSym of attrTypes.getProperties()) {
+        args.push(subpropSym.getName());
+      }
+    }
+  }
+  return args;
+}
+
+function getComponentArgsFromChildren(
+  _checker: ts.TypeChecker,
+  tscElementNode: ts.JsxElement | ts.JsxSelfClosingElement
+): [string, ts.JsxElement | ts.JsxSelfClosingElement][] {
+  let counter = 0;
+  const args: [string, ts.JsxElement | ts.JsxSelfClosingElement][] = [];
+
+  search(tscElementNode);
+  function search(elem: ts.JsxElement | ts.JsxSelfClosingElement) {
+    if (ts.isJsxSelfClosingElement(elem)) return;
+
+    for (const child of elem.children) {
+      if (ts.isJsxElement(child) || ts.isJsxSelfClosingElement(child)) {
+        const key = findKey(getOpenTag(child)) ?? `${counter++}`;
+        args.push([key, child]);
+        search(child);
+      }
+    }
+  }
+
+  return args;
+}
+
+function extractTypeAlias(
+  ty: ts.Type,
+  name: string,
+  length: number
+): readonly ts.Type[] | undefined {
+  if (ty.aliasSymbol) {
+    if (ty.aliasSymbol.getName() !== name) return undefined;
+
+    if (!ty.aliasTypeArguments) return undefined;
+    if (ty.aliasTypeArguments.length < length) return undefined;
+
+    return ty.aliasTypeArguments;
+  } else if (isTypeReference(ty)) {
+    const tysym = ty.getSymbol();
+    if (!tysym) return undefined;
+    if (tysym.getName() !== name) return undefined;
+
+    if (!ty.typeArguments) return undefined;
+    if (ty.typeArguments.length < length) return undefined;
+
+    return ty.typeArguments;
+  }
+  return undefined;
+}
+
+function findKey(tag: ts.JsxOpeningLikeElement): string | undefined {
+  for (const prop of tag.attributes.properties) {
+    if (!ts.isJsxAttribute(prop)) continue;
+    if (prop.name.text !== "key") continue;
+
+    if (prop.initializer) {
+      if (ts.isStringLiteral(prop.initializer)) {
+        return prop.initializer.text;
+      } else if (ts.isJsxExpression(prop.initializer)) {
+        if (
+          prop.initializer.expression &&
+          ts.isStringLiteralLike(prop.initializer.expression)
+        ) {
+          return prop.initializer.expression.text;
+        }
+      }
+    }
+
+    return "__invalid_key__";
+  }
+  return undefined;
+}
+
+function getOpenTag(
+  elem: ts.JsxElement | ts.JsxSelfClosingElement
+): ts.JsxOpeningLikeElement {
+  if (ts.isJsxSelfClosingElement(elem)) {
+    return elem;
+  } else {
+    return elem.openingElement;
+  }
+}
+
+function isTypeReference(ty: ts.Type): ty is ts.TypeReference {
+  return !!(
+    ty.flags & ts.TypeFlags.Object &&
+    (ty as ts.ObjectType).objectFlags & ts.ObjectFlags.Reference
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1553,10 +1553,15 @@ __metadata:
     "@babel/preset-env": ^7.18.6
     "@babel/preset-typescript": ^7.18.6
     "@babel/runtime": ^7.18.3
+    "@hi18n/core": "workspace:*"
+    "@hi18n/react": "workspace:*"
+    "@hi18n/react-context": "workspace:*"
     "@jest/globals": ^28.1.2
     "@types/babel__core": ^7.1.19
     "@types/eslint": ^8.4.5
     "@types/node": ^17.0.32
+    "@types/react": ^18.0.14
+    "@typescript-eslint/parser": ^5.30.4
     "@typescript-eslint/types": ^5.30.4
     "@typescript-eslint/utils": ^5.22.0
     babel-jest: ^28.1.2
@@ -1569,14 +1574,19 @@ __metadata:
     espree: ^9.3.2
     jest: ^28.1.2
     prettier: ^2.7.1
+    react: ^18.2.0
     rimraf: ^3.0.2
     typescript: ^4.7.4
   peerDependencies:
     eslint: ^7.0.0 || ^8.0.0
+    typescript: "*"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
   languageName: unknown
   linkType: soft
 
-"@hi18n/react-context@workspace:^0.1.0, @hi18n/react-context@workspace:packages/react-context":
+"@hi18n/react-context@workspace:*, @hi18n/react-context@workspace:^0.1.0, @hi18n/react-context@workspace:packages/react-context":
   version: 0.0.0-use.local
   resolution: "@hi18n/react-context@workspace:packages/react-context"
   dependencies:
@@ -1588,7 +1598,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@hi18n/react@workspace:packages/react":
+"@hi18n/react@workspace:*, @hi18n/react@workspace:packages/react":
   version: 0.0.0-use.local
   resolution: "@hi18n/react@workspace:packages/react"
   dependencies:
@@ -2351,6 +2361,17 @@ __metadata:
     "@types/scheduler": "*"
     csstype: ^3.0.2
   checksum: 12d0e6bc390709926d8eaeb7d2edb4ef9c9fbe8eac41cb0619d958386700547bff91c880c2a12a9eb1e0d09afa4f1e86fd1b93164c627824465b72123f149f3b
+  languageName: node
+  linkType: hard
+
+"@types/react@npm:^18.0.14":
+  version: 18.0.14
+  resolution: "@types/react@npm:18.0.14"
+  dependencies:
+    "@types/prop-types": "*"
+    "@types/scheduler": "*"
+    csstype: ^3.0.2
+  checksum: 608eb57a383eedc54c79949673e5e8314f6b0c61542bff58721c8c47a18c23e2832e77c656050c2c2c004b62cf25582136c7c56fe1b6263a285c065fae31dbcf
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1899,19 +1899,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/types@npm:^27.5.1":
-  version: 27.5.1
-  resolution: "@jest/types@npm:27.5.1"
-  dependencies:
-    "@types/istanbul-lib-coverage": ^2.0.0
-    "@types/istanbul-reports": ^3.0.0
-    "@types/node": "*"
-    "@types/yargs": ^16.0.0
-    chalk: ^4.0.0
-  checksum: d1f43cc946d87543ddd79d49547aab2399481d34025d5c5f2025d3d99c573e1d9832fa83cef25e9d9b07a8583500229d15bbb07b8e233d127d911d133e2f14b1
-  languageName: node
-  linkType: hard
-
 "@jest/types@npm:^28.1.1":
   version: 28.1.1
   resolution: "@jest/types@npm:28.1.1"
@@ -2220,7 +2207,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/graceful-fs@npm:^4.1.2, @types/graceful-fs@npm:^4.1.3":
+"@types/graceful-fs@npm:^4.1.3":
   version: 4.1.5
   resolution: "@types/graceful-fs@npm:4.1.5"
   dependencies:
@@ -2431,15 +2418,6 @@ __metadata:
   version: 21.0.0
   resolution: "@types/yargs-parser@npm:21.0.0"
   checksum: b2f4c8d12ac18a567440379909127cf2cec393daffb73f246d0a25df36ea983b93b7e9e824251f959e9f928cbc7c1aab6728d0a0ff15d6145f66cec2be67d9a2
-  languageName: node
-  linkType: hard
-
-"@types/yargs@npm:^16.0.0":
-  version: 16.0.4
-  resolution: "@types/yargs@npm:16.0.4"
-  dependencies:
-    "@types/yargs-parser": "*"
-  checksum: caa21d2c957592fe2184a8368c8cbe5a82a6c2e2f2893722e489f842dc5963293d2f3120bc06fe3933d60a3a0d1e2eb269649fd6b1947fe1820f8841ba611dd9
   languageName: node
   linkType: hard
 
@@ -5217,30 +5195,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-haste-map@npm:^27.5.1":
-  version: 27.5.1
-  resolution: "jest-haste-map@npm:27.5.1"
-  dependencies:
-    "@jest/types": ^27.5.1
-    "@types/graceful-fs": ^4.1.2
-    "@types/node": "*"
-    anymatch: ^3.0.3
-    fb-watchman: ^2.0.0
-    fsevents: ^2.3.2
-    graceful-fs: ^4.2.9
-    jest-regex-util: ^27.5.1
-    jest-serializer: ^27.5.1
-    jest-util: ^27.5.1
-    jest-worker: ^27.5.1
-    micromatch: ^4.0.4
-    walker: ^1.0.7
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  checksum: e092a1412829a9254b4725531ee72926de530f77fda7b0d9ea18008fb7623c16f72e772d8e93be71cac9e591b2c6843a669610887dd2c89bd9eb528856e3ab47
-  languageName: node
-  linkType: hard
-
 "jest-haste-map@npm:^28.1.1":
   version: 28.1.1
   resolution: "jest-haste-map@npm:28.1.1"
@@ -5337,13 +5291,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-regex-util@npm:^27.5.1":
-  version: 27.5.1
-  resolution: "jest-regex-util@npm:27.5.1"
-  checksum: d45ca7a9543616a34f7f3079337439cf07566e677a096472baa2810e274b9808b76767c97b0a4029b8a5b82b9d256dee28ef9ad4138b2b9e5933f6fac106c418
-  languageName: node
-  linkType: hard
-
 "jest-regex-util@npm:^28.0.2":
   version: 28.0.2
   resolution: "jest-regex-util@npm:28.0.2"
@@ -5361,25 +5308,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-resolve@npm:^27.2.5":
-  version: 27.5.1
-  resolution: "jest-resolve@npm:27.5.1"
-  dependencies:
-    "@jest/types": ^27.5.1
-    chalk: ^4.0.0
-    graceful-fs: ^4.2.9
-    jest-haste-map: ^27.5.1
-    jest-pnp-resolver: ^1.2.2
-    jest-util: ^27.5.1
-    jest-validate: ^27.5.1
-    resolve: ^1.20.0
-    resolve.exports: ^1.1.0
-    slash: ^3.0.0
-  checksum: 735830e7265b20a348029738680bb2f6e37f80ecea86cda869a4c318ba3a45d39c7a3a873a22f7f746d86258c50ead6e7f501de043e201c095d7ba628a1c440f
-  languageName: node
-  linkType: hard
-
-"jest-resolve@npm:^28.1.1":
+"jest-resolve@npm:28.1.1":
   version: 28.1.1
   resolution: "jest-resolve@npm:28.1.1"
   dependencies:
@@ -5393,6 +5322,23 @@ __metadata:
     resolve.exports: ^1.1.0
     slash: ^3.0.0
   checksum: cda5c472fe5b50b91696d90d5c3a72d0f5ff188ecad18816b4085fbac0bad53c0a9abff94c3bf41c7ced24256cf8e34f0b03f1c9e05464e8efcd0f03560d6699
+  languageName: node
+  linkType: hard
+
+"jest-resolve@patch:jest-resolve@npm:28.1.1#.yarn/patches/jest-resolve-npm-28.1.1-5f1937a1f8.patch::locator=root%40workspace%3A.":
+  version: 28.1.1
+  resolution: "jest-resolve@patch:jest-resolve@npm%3A28.1.1#.yarn/patches/jest-resolve-npm-28.1.1-5f1937a1f8.patch::version=28.1.1&hash=bc6821&locator=root%40workspace%3A."
+  dependencies:
+    chalk: ^4.0.0
+    graceful-fs: ^4.2.9
+    jest-haste-map: ^28.1.1
+    jest-pnp-resolver: ^1.2.2
+    jest-util: ^28.1.1
+    jest-validate: ^28.1.1
+    resolve: ^1.20.0
+    resolve.exports: ^1.1.0
+    slash: ^3.0.0
+  checksum: 27eceac1dc4c44b9ca3a0ca4bba70d420adfe127d110d813ae727d16f5457910ba8bcba37129b863468b07f0aa5252d15481a48f306d84ceb2448e886baeac20
   languageName: node
   linkType: hard
 
@@ -5455,16 +5401,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-serializer@npm:^27.5.1":
-  version: 27.5.1
-  resolution: "jest-serializer@npm:27.5.1"
-  dependencies:
-    "@types/node": "*"
-    graceful-fs: ^4.2.9
-  checksum: 803e03a552278610edc6753c0dd9fa5bb5cd3ca47414a7b2918106efb62b79fd5e9ae785d0a21f12a299fa599fea8acc1fa6dd41283328cee43962cf7df9bb44
-  languageName: node
-  linkType: hard
-
 "jest-snapshot@npm:^28.1.2":
   version: 28.1.2
   resolution: "jest-snapshot@npm:28.1.2"
@@ -5496,20 +5432,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-util@npm:^27.5.1":
-  version: 27.5.1
-  resolution: "jest-util@npm:27.5.1"
-  dependencies:
-    "@jest/types": ^27.5.1
-    "@types/node": "*"
-    chalk: ^4.0.0
-    ci-info: ^3.2.0
-    graceful-fs: ^4.2.9
-    picomatch: ^2.2.3
-  checksum: ac8d122f6daf7a035dcea156641fd3701aeba245417c40836a77e35b3341b9c02ddc5d904cfcd4ddbaa00ab854da76d3b911870cafdcdbaff90ea471de26c7d7
-  languageName: node
-  linkType: hard
-
 "jest-util@npm:^28.1.1":
   version: 28.1.1
   resolution: "jest-util@npm:28.1.1"
@@ -5521,20 +5443,6 @@ __metadata:
     graceful-fs: ^4.2.9
     picomatch: ^2.2.3
   checksum: bca1601099d6a4c3c4ba997b8c035a698f23b9b04a0a284a427113f7d0399f7402ba9f4d73812328e6777bf952bf93dfe3d3edda6380a6ca27cdc02768d601e0
-  languageName: node
-  linkType: hard
-
-"jest-validate@npm:^27.5.1":
-  version: 27.5.1
-  resolution: "jest-validate@npm:27.5.1"
-  dependencies:
-    "@jest/types": ^27.5.1
-    camelcase: ^6.2.0
-    chalk: ^4.0.0
-    jest-get-type: ^27.5.1
-    leven: ^3.1.0
-    pretty-format: ^27.5.1
-  checksum: 82e870f8ee7e4fb949652711b1567f05ae31c54be346b0899e8353e5c20fad7692b511905b37966945e90af8dc0383eb41a74f3ffefb16140ea4f9164d841412
   languageName: node
   linkType: hard
 
@@ -5565,17 +5473,6 @@ __metadata:
     jest-util: ^28.1.1
     string-length: ^4.0.1
   checksum: 60ee90a3b760db2bc57173a0f3fc44f3162491e1ca4cf6a0e99d40bea3825e2a20c47c3ba13ebcbaea09cd2e4fe338c41841a972d9fe49ed7bbf3f34d2734ebd
-  languageName: node
-  linkType: hard
-
-"jest-worker@npm:^27.5.1":
-  version: 27.5.1
-  resolution: "jest-worker@npm:27.5.1"
-  dependencies:
-    "@types/node": "*"
-    merge-stream: ^2.0.0
-    supports-color: ^8.0.0
-  checksum: 98cd68b696781caed61c983a3ee30bf880b5bd021c01d98f47b143d4362b85d0737f8523761e2713d45e18b4f9a2b98af1eaee77afade4111bb65c77d6f7c980
   languageName: node
   linkType: hard
 
@@ -7629,7 +7526,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"walker@npm:^1.0.7, walker@npm:^1.0.8":
+"walker@npm:^1.0.8":
   version: 1.0.8
   resolution: "walker@npm:1.0.8"
   dependencies:


### PR DESCRIPTION
## Why

In TypeScript every JSX element has the same type and we cannot check if the children inside `<Translate>` is written correctly.

## What

To complement this, added a lint `@hi18n/react-component-params` that does additional checks based on the type info.

Also added a new preset `plugin:@hi18n/recommended-requiring-type-checking` similarly to [`plugin:@typescript-eslint/recommended-requiring-type-checking`](https://typescript-eslint.io/docs/linting/type-linting/).