### PR TITLE
build: Delete 'bin' field from package.json

### DIFF
--- a/packages/connector-i18n-js/CHANGELOG.md
+++ b/packages/connector-i18n-js/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Fix: remove wrong "bin" field from package manifest
+
 ## 0.1.0
 
 Initial release.

--- a/packages/connector-i18n-js/package.json
+++ b/packages/connector-i18n-js/package.json
@@ -34,9 +34,6 @@
     "!src/**/*.test.ts",
     "!src/__fixtures__/**/*"
   ],
-  "bin": {
-    "hi18n": "./bin/hi18n.js"
-  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/dev-utils/package.json
+++ b/packages/dev-utils/package.json
@@ -33,9 +33,6 @@
     "src/**/*",
     "!src/**/*.test.ts"
   ],
-  "bin": {
-    "hi18n": "./bin/hi18n.js"
-  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/tools-core/CHANGELOG.md
+++ b/packages/tools-core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Fix: remove wrong "bin" field from package manifest
+
 ## 0.1.0
 
 Initial release.

--- a/packages/tools-core/package.json
+++ b/packages/tools-core/package.json
@@ -33,9 +33,6 @@
     "src/**/*",
     "!src/**/*.test.ts"
   ],
-  "bin": {
-    "hi18n": "./bin/hi18n.js"
-  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1559,8 +1559,6 @@ __metadata:
     prettier: ^2.7.1
     rimraf: ^3.0.2
     typescript: ^4.8.2
-  bin:
-    hi18n: ./bin/hi18n.js
   languageName: unknown
   linkType: soft
 
@@ -1613,8 +1611,6 @@ __metadata:
     prettier: ^2.7.1
     rimraf: ^3.0.2
     typescript: ^4.8.2
-  bin:
-    hi18n: ./bin/hi18n.js
   languageName: unknown
   linkType: soft
 
@@ -1736,8 +1732,6 @@ __metadata:
     prettier: ^2.7.1
     rimraf: ^3.0.2
     typescript: ^4.8.2
-  bin:
-    hi18n: ./bin/hi18n.js
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Why

There is "bin" field in `package.json` even when the corresponding bin directory doesn't exist.
And this causes an error when you run `npm rebuild`.

![Pasted_Image_2022_09_29_11_06](https://user-images.githubusercontent.com/6651523/192922241-668bbf0b-2441-44c9-b3d0-b7063e06e8bb.png)


## What

Remove wasted `bin` fields from `package.json`.