### PR TITLE
chore(misc): use pnpm mode

### DIFF
--- a/.changeset/use-pnpm-mode.md
+++ b/.changeset/use-pnpm-mode.md
@@ -1,0 +1,13 @@
+---
+"@hi18n/cli": patch
+"@hi18n/connector-i18n-js": patch
+"@hi18n/core": patch
+"@hi18n/dev-utils": patch
+"@hi18n/eslint-plugin": patch
+"@hi18n/react": patch
+"@hi18n/react-context": patch
+"@hi18n/tools-core": patch
+"@hi18n/ts-plugin": patch
+---
+
+chore(misc): use pnpm mode

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,6 +2,8 @@ compressionLevel: mixed
 
 enableGlobalCache: false
 
+nodeLinker: pnpm
+
 packageExtensions:
   babel-plugin-replace-import-extension@*:
     peerDependencies:

--- a/packages/react-context/package.json
+++ b/packages/react-context/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "eslint": "^8.24.0",
-    "prettier": "^2.7.1"
+    "prettier": "^2.7.1",
+    "react": "^18.2.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1666,6 +1666,7 @@ __metadata:
     "@types/react": "npm:^16.3.11 || ^17.0.0 || ^18.0.0"
     eslint: "npm:^8.24.0"
     prettier: "npm:^2.7.1"
+    react: "npm:^18.2.0"
   peerDependencies:
     react: ^16.3.0 || ^17.0.0 || ^18.0.0
   languageName: unknown


### PR DESCRIPTION
## Why

Still in 2025, TypeScript refuses to merge the yarn PnP patch, and the overall usability of yarn PnP remains poor.

## What

Use the pnpm mode (not pnpm itself) instead.