### PR TITLE
chore(misc): Sort CHANGELOG in ascending order

### DIFF
--- a/.changeset/seven-months-fly.md
+++ b/.changeset/seven-months-fly.md
@@ -1,0 +1,10 @@
+---
+"@hi18n/connector-i18n-js": patch
+"@hi18n/eslint-plugin": patch
+"@hi18n/tools-core": patch
+"@hi18n/react": patch
+"@hi18n/core": patch
+"@hi18n/cli": patch
+---
+
+chore(misc): Sort CHANGELOG in ascending order

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,29 +1,31 @@
-## 0.1.11
+## 0.1.0
 
-- Bump `@hi18n/tools-core`
+Initial release.
 
-## 0.1.10
+## 0.1.1
 
-- Add `connector`/`connectorOptions` configurations.
-- Add `hi18n export` command.
-  - When `connector` is configured, it exports hi18n's translation data to the specified format.
-- Implement passive importing in `hi18n sync`.
-  - When `connector` is configured, the corresponding external source is referenced
-    to complement missing translations.
+- Fix binary name
 
-## 0.1.9
+## 0.1.2
 
-- Add `config.include` and `config.exclude` options in `.hi18nrc.js` that replace the corresponding command line options.
-  - Just type `hi18n sync` and you get your translations synchronized.
-  - This is now a recommended way to configure the command.
+- Add support for `translationId`, `t.todo` and `<Translate.Todo>`
 
-## 0.1.8
+## 0.1.3
 
-- Support dynamically-loaded Catalogs introduced in `@hi18n/core` 0.1.9.
+- Add prepack script. It allows you to use unreleased versions from git with yarn v2 or later.
+- Fix error where codes like `const [, x] = [];` cannot appear with `import { Translate } from "@hi18n/react";`.
 
-## 0.1.7
+## 0.1.4
 
-- Support a new overload for `new Catalog` constructor introduced in `@hi18n/core` 0.1.6. It accepts a locale identifier as the first argument.
+- Placeholder is changed from `msg()` to `msg.todo("[TODO: example/greeting]")`.
+
+## 0.1.5
+
+- Implement `hi18n sync --check` (shorthand: `-c`) option to raise an error when files would be changed.
+  It is useful when you want to ensure synchronization in your CI.
+- Switched command line parser (yargs to commander). The behavior may slightly change.
+- Fix `TypeError: Cannot read properties of undefined (reading 'node')`
+  on an empty Vocabulary or an empty Catalog.
 
 ## 0.1.6
 
@@ -35,31 +37,29 @@
 - Allow configuring parsers
   - You can have `parser` and `parserOptions` configurations very much like in `.eslintrc`.
 
-## 0.1.5
+## 0.1.7
 
-- Implement `hi18n sync --check` (shorthand: `-c`) option to raise an error when files would be changed.
-  It is useful when you want to ensure synchronization in your CI.
-- Switched command line parser (yargs to commander). The behavior may slightly change.
-- Fix `TypeError: Cannot read properties of undefined (reading 'node')`
-  on an empty Vocabulary or an empty Catalog.
+- Support a new overload for `new Catalog` constructor introduced in `@hi18n/core` 0.1.6. It accepts a locale identifier as the first argument.
 
-## 0.1.4
+## 0.1.8
 
-- Placeholder is changed from `msg()` to `msg.todo("[TODO: example/greeting]")`.
+- Support dynamically-loaded Catalogs introduced in `@hi18n/core` 0.1.9.
 
-## 0.1.3
+## 0.1.9
 
-- Add prepack script. It allows you to use unreleased versions from git with yarn v2 or later.
-- Fix error where codes like `const [, x] = [];` cannot appear with `import { Translate } from "@hi18n/react";`.
+- Add `config.include` and `config.exclude` options in `.hi18nrc.js` that replace the corresponding command line options.
+  - Just type `hi18n sync` and you get your translations synchronized.
+  - This is now a recommended way to configure the command.
 
-## 0.1.2
+## 0.1.10
 
-- Add support for `translationId`, `t.todo` and `<Translate.Todo>`
+- Add `connector`/`connectorOptions` configurations.
+- Add `hi18n export` command.
+  - When `connector` is configured, it exports hi18n's translation data to the specified format.
+- Implement passive importing in `hi18n sync`.
+  - When `connector` is configured, the corresponding external source is referenced
+    to complement missing translations.
 
-## 0.1.1
+## 0.1.11
 
-- Fix binary name
-
-## 0.1.0
-
-Initial release.
+- Bump `@hi18n/tools-core`

--- a/packages/connector-i18n-js/CHANGELOG.md
+++ b/packages/connector-i18n-js/CHANGELOG.md
@@ -1,7 +1,7 @@
-## 0.1.1
-
-- Fix: remove wrong "bin" field from package manifest
-
 ## 0.1.0
 
 Initial release.
+
+## 0.1.1
+
+- Fix: remove wrong "bin" field from package manifest

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,20 +1,52 @@
-## 0.1.10
+## 0.1.0
 
-- Prevent minifier from changing error name
+Initial release.
 
-## 0.1.9
+## 0.1.1
 
-- New APIs for dynamically loading Catalogs of specific languages.
-  - Generalized `Book` constructor. Now you can pass lazy-loading function `() => import("...")` where a catalog object has been expected.
-  - `preloadCatalogs(book, locales)` to start loading catalogs. There is also `Book.prototype.loadCatalog()` but the former is preferred.
-  - `getTranslator` accepts a new `throwPromise` option. When `throwPromise` is true, it throws a Promise instance instead of a "catalog not loaded" error. This is used to support React Suspense in `@hi18n/react`.
+- Add `translationId` and `t.dynamic` for dynamically selecting translations
+- Add `t.todo` for bootstrapping new translations
 
-## 0.1.8
+## 0.1.2
 
-- Implement fallbacks in case of missing Intl in the following cases:
-  - If `Intl.NumberFormat` is missing, it falls back to `toString` in `{arg,number}` and `{arg,number,integer}`.
-  - If `Intl.PluralRules` is missing, it falls back to the "other" branch in `{arg,plural,...}`.
-    - Exact matches like `=0` are still valid.
+- Add prepack script. It allows you to use unreleased versions from git with yarn v2 or later.
+- Add `"sideEffects": false` for better tree-shaking.
+- Accept multiple locales in `getTranslator`. For now, only the first element is relevant.
+
+## 0.1.3
+
+- Support `#` in plural translations.
+- Implement `{foo,number,integer}` and `{foo,number,percent}` formats.
+- Implement the following date/time formats:
+  - `{foo,date}`
+  - `{foo,date,short}`
+  - `{foo,date,medium}`
+  - `{foo,date,long}`
+  - `{foo,date,full}`
+  - `{foo,date,::MMMMdjmm}`, etc. where `MMMMdjmm` is a format string called skeleton.
+  - `{foo,time}`
+  - `{foo,time,short}`
+  - `{foo,time,medium}`
+  - `{foo,time,long}`
+  - `{foo,time,full}`
+- Add `msg.todo`.
+
+## 0.1.4
+
+- Support `offset:` parameter in plural translations.
+- Fix bug where date skeletons `{foo,date,::MMMMdjmm}` is not actually applied.
+
+## 0.1.5
+
+- Include less polyfills from core-js.
+- Reduce polyfill for matchAll and Array.prototype.includes.
+- Fix error when Date is mocked in a certain way like `@sinonjs/fake-timers`.
+
+## 0.1.6
+
+- Add a new overload for `new Catalog` constructor. It accepts a locale identifier as the first argument.
+  - Please make sure to update the ESLint plugin / CLI too to support the new format.
+  - The old overload is deprecated.
 
 ## 0.1.7
 
@@ -35,52 +67,20 @@
   - `MissingArgumentError`
   - `ArgumentTypeError`
 
-## 0.1.6
+## 0.1.8
 
-- Add a new overload for `new Catalog` constructor. It accepts a locale identifier as the first argument.
-  - Please make sure to update the ESLint plugin / CLI too to support the new format.
-  - The old overload is deprecated.
+- Implement fallbacks in case of missing Intl in the following cases:
+  - If `Intl.NumberFormat` is missing, it falls back to `toString` in `{arg,number}` and `{arg,number,integer}`.
+  - If `Intl.PluralRules` is missing, it falls back to the "other" branch in `{arg,plural,...}`.
+    - Exact matches like `=0` are still valid.
 
-## 0.1.5
+## 0.1.9
 
-- Include less polyfills from core-js.
-- Reduce polyfill for matchAll and Array.prototype.includes.
-- Fix error when Date is mocked in a certain way like `@sinonjs/fake-timers`.
+- New APIs for dynamically loading Catalogs of specific languages.
+  - Generalized `Book` constructor. Now you can pass lazy-loading function `() => import("...")` where a catalog object has been expected.
+  - `preloadCatalogs(book, locales)` to start loading catalogs. There is also `Book.prototype.loadCatalog()` but the former is preferred.
+  - `getTranslator` accepts a new `throwPromise` option. When `throwPromise` is true, it throws a Promise instance instead of a "catalog not loaded" error. This is used to support React Suspense in `@hi18n/react`.
 
-## 0.1.4
+## 0.1.10
 
-- Support `offset:` parameter in plural translations.
-- Fix bug where date skeletons `{foo,date,::MMMMdjmm}` is not actually applied.
-
-## 0.1.3
-
-- Support `#` in plural translations.
-- Implement `{foo,number,integer}` and `{foo,number,percent}` formats.
-- Implement the following date/time formats:
-  - `{foo,date}`
-  - `{foo,date,short}`
-  - `{foo,date,medium}`
-  - `{foo,date,long}`
-  - `{foo,date,full}`
-  - `{foo,date,::MMMMdjmm}`, etc. where `MMMMdjmm` is a format string called skeleton.
-  - `{foo,time}`
-  - `{foo,time,short}`
-  - `{foo,time,medium}`
-  - `{foo,time,long}`
-  - `{foo,time,full}`
-- Add `msg.todo`.
-
-## 0.1.2
-
-- Add prepack script. It allows you to use unreleased versions from git with yarn v2 or later.
-- Add `"sideEffects": false` for better tree-shaking.
-- Accept multiple locales in `getTranslator`. For now, only the first element is relevant.
-
-## 0.1.1
-
-- Add `translationId` and `t.dynamic` for dynamically selecting translations
-- Add `t.todo` for bootstrapping new translations
-
-## 0.1.0
-
-Initial release.
+- Prevent minifier from changing error name

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -1,15 +1,31 @@
-## 0.1.9
+## 0.1.0
 
-- Add internal APIs for passive importing in `@hi18n/cli`.
-- Add defaultOptions to the rules (to fix type error with recent typescript-eslint)
+Initial release.
 
-## 0.1.8
+## 0.1.1
 
-- Support dynamically-loaded Catalogs introduced in `@hi18n/core` 0.1.9.
+- Fix wrong rule names in the recommended config
 
-## 0.1.7
+## 0.1.2
 
-- Support a new overload for `new Catalog` constructor introduced in `@hi18n/core` 0.1.6. It accepts a locale identifier as the first argument.
+- Internal: add support for `translationId`, `t.todo` and `<Translate.Todo>` (for use in `@hi18n/cli`)
+
+## 0.1.3
+
+- Add prepack script. It allows you to use unreleased versions from git with yarn v2 or later.
+- Add a new rule `@hi18n/migrate-from-lingui` implementing semi-automatic codemod as autofix.
+  This rule is turned off by default.
+- Fix error where codes like `const [, x] = [];` cannot appear with `import { Translate } from "@hi18n/react";`.
+
+## 0.1.4
+
+- Automatically include the plugin in the "recommended" config.
+- Internal: add support for `msg.todo` (for use in `@hi18n/cli`)
+
+## 0.1.5
+
+- Fix `TypeError: Cannot read properties of undefined (reading 'node')`
+  on an empty Vocabulary or an empty Catalog in internally used rules.
 
 ## 0.1.6
 
@@ -19,31 +35,15 @@
   - `@hi18n/react-component-params` is included in this preset.
 - Corner case bug fix on `new Book<this>()`
 
-## 0.1.5
+## 0.1.7
 
-- Fix `TypeError: Cannot read properties of undefined (reading 'node')`
-  on an empty Vocabulary or an empty Catalog in internally used rules.
+- Support a new overload for `new Catalog` constructor introduced in `@hi18n/core` 0.1.6. It accepts a locale identifier as the first argument.
 
-## 0.1.4
+## 0.1.8
 
-- Automatically include the plugin in the "recommended" config.
-- Internal: add support for `msg.todo` (for use in `@hi18n/cli`)
+- Support dynamically-loaded Catalogs introduced in `@hi18n/core` 0.1.9.
 
-## 0.1.3
+## 0.1.9
 
-- Add prepack script. It allows you to use unreleased versions from git with yarn v2 or later.
-- Add a new rule `@hi18n/migrate-from-lingui` implementing semi-automatic codemod as autofix.
-  This rule is turned off by default.
-- Fix error where codes like `const [, x] = [];` cannot appear with `import { Translate } from "@hi18n/react";`.
-
-## 0.1.2
-
-- Internal: add support for `translationId`, `t.todo` and `<Translate.Todo>` (for use in `@hi18n/cli`)
-
-## 0.1.1
-
-- Fix wrong rule names in the recommended config
-
-## 0.1.0
-
-Initial release.
+- Add internal APIs for passive importing in `@hi18n/cli`.
+- Add defaultOptions to the rules (to fix type error with recent typescript-eslint)

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,16 +1,12 @@
-## 0.1.5
+## 0.1.0
 
-- Add support for dynamically loading Catalogs of specific languages. For details, see the changelog for `@hi18n/core` 0.1.9.
+Initial release.
 
-## 0.1.4
+## 0.1.1
 
-- Allow using one React element multiple times in a translation.
-  You can now add translations like `A<0/>B<0/>C` which uses
-  the element `0` twice.
-
-## 0.1.3
-
-- Include less polyfills from core-js.
+- Add `Translate.Dynamic` for dynamically selecting translations
+- Add `Translate.Todo` for bootstrapping new translations
+- Fix "Cannot find module react/jsx-runtime" error with ESM (dist/index.mjs).
 
 ## 0.1.2
 
@@ -22,12 +18,16 @@
   You get the identical object or function in the same element until the book or the locale changes.
 - Add `renderInElement` prop to `<Translate>`.
 
-## 0.1.1
+## 0.1.3
 
-- Add `Translate.Dynamic` for dynamically selecting translations
-- Add `Translate.Todo` for bootstrapping new translations
-- Fix "Cannot find module react/jsx-runtime" error with ESM (dist/index.mjs).
+- Include less polyfills from core-js.
 
-## 0.1.0
+## 0.1.4
 
-Initial release.
+- Allow using one React element multiple times in a translation.
+  You can now add translations like `A<0/>B<0/>C` which uses
+  the element `0` twice.
+
+## 0.1.5
+
+- Add support for dynamically loading Catalogs of specific languages. For details, see the changelog for `@hi18n/core` 0.1.9.

--- a/packages/tools-core/CHANGELOG.md
+++ b/packages/tools-core/CHANGELOG.md
@@ -1,7 +1,7 @@
-## 0.1.1
-
-- Fix: remove wrong "bin" field from package manifest
-
 ## 0.1.0
 
 Initial release.
+
+## 0.1.1
+
+- Fix: remove wrong "bin" field from package manifest


### PR DESCRIPTION
## Why

Changesets expects CHANGELOG to be in ascending order.

## What

Reverse the order in which the versions are listed.