### PR TITLE
fix(monorepo): ensure workspace dependencies are removed from published materials

### DIFF
--- a/.changeset/smooth-boats-scream.md
+++ b/.changeset/smooth-boats-scream.md
@@ -5,4 +5,4 @@
 "@hi18n/react": patch
 ---
 
-fix(monorepo): ensure workspace dependencies from published materials
+fix(monorepo): ensure workspace dependencies are removed from published materials

--- a/.changeset/smooth-boats-scream.md
+++ b/.changeset/smooth-boats-scream.md
@@ -1,0 +1,8 @@
+---
+"@hi18n/cli": patch
+"@hi18n/connector-i18n-js": patch
+"@hi18n/eslint-plugin": patch
+"@hi18n/react": patch
+---
+
+fix(monorepo): ensure workspace dependencies from published materials

--- a/.yarn/patches/@changesets-cli-npm-2.29.6-ac8361deb8.patch
+++ b/.yarn/patches/@changesets-cli-npm-2.29.6-ac8361deb8.patch
@@ -1,0 +1,110 @@
+diff --git a/dist/changesets-cli.cjs.js b/dist/changesets-cli.cjs.js
+index 53fc925f8aa492e7333033483e9f3e45839963ad..0ac9f0a347caa4943f882c8d657b0da0c6443bf2 100644
+--- a/dist/changesets-cli.cjs.js
++++ b/dist/changesets-cli.cjs.js
+@@ -634,9 +634,10 @@ async function getPublishTool(cwd) {
+   const pm = await packageManagerDetector.detect({
+     cwd
+   });
+-  if (!pm || pm.name !== "pnpm") return {
++  if (!pm) return {
+     name: "npm"
+   };
++  if (pn.name === "pnpm") {
+   try {
+     let result = await spawn__default["default"]("pnpm", ["--version"], {
+       cwd
+@@ -653,6 +654,28 @@ async function getPublishTool(cwd) {
+       shouldAddNoGitChecks: false
+     };
+   }
++  }
++  if (pm.name === "yarn") {
++    try {
++      let result = await spawn__default.default("yarn", ["--version"], { cwd });
++      let version = result.stdout.toString().trim();
++      let parsed = semverParse__default.default(version);
++
++      // Yarn v2 introduced `yarn npm publish` which should be used
++      // to ensure packages are packed correctly prior to publishing
++      if (parsed != null && parsed.major >= 2) {
++        return {
++          name: "yarn",
++          version: parsed,
++        };
++      }
++      return { name: "npm" };
++    } catch (e) {
++      return { name: "npm" };
++    }
++  }
++
++  return { name: "npm" };
+ }
+ async function getTokenIsRequired() {
+   const {
+@@ -771,6 +794,9 @@ async function internalPublish(packageJson, opts, twoFactorState) {
+   } = publishTool.name === "pnpm" ? await spawn__default["default"]("pnpm", ["publish", "--json", ...publishFlags], {
+     env: Object.assign({}, process.env, envOverride),
+     cwd: opts.cwd
++  }) : publishTool.name === "yarn" ? await spawn__default.default("yarn", ["publish", "--json", ...publishFlags], {
++    env: Object.assign({}, process.env, envOverride),
++    cwd: opts.cwd
+   }) : await spawn__default["default"](publishTool.name, ["publish", opts.publishDir, "--json", ...publishFlags], {
+     env: Object.assign({}, process.env, envOverride)
+   });
+diff --git a/dist/changesets-cli.esm.js b/dist/changesets-cli.esm.js
+index 6c363c0551d7a5b69e2e48be0bcd757699609094..ee0daec368d5ad32f5a6640ad3982ec4da76b1e0 100644
+--- a/dist/changesets-cli.esm.js
++++ b/dist/changesets-cli.esm.js
+@@ -596,9 +596,10 @@ async function getPublishTool(cwd) {
+   const pm = await detect({
+     cwd
+   });
+-  if (!pm || pm.name !== "pnpm") return {
++  if (!pm) return {
+     name: "npm"
+   };
++  if (pn.name === "pnpm") {
+   try {
+     let result = await spawn$1("pnpm", ["--version"], {
+       cwd
+@@ -615,6 +616,28 @@ async function getPublishTool(cwd) {
+       shouldAddNoGitChecks: false
+     };
+   }
++  }
++  if (pm.name === "yarn") {
++    try {
++      let result = await spawn$1("yarn", ["--version"], { cwd });
++      let version = result.stdout.toString().trim();
++      let parsed = semverParse(version);
++
++      // Yarn v2 introduced `yarn npm publish` which should be used
++      // to ensure packages are packed correctly prior to publishing
++      if (parsed != null && parsed.major >= 2) {
++        return {
++          name: "yarn",
++          version: parsed,
++        };
++      }
++      return { name: "npm" };
++    } catch (e) {
++      return { name: "npm" };
++    }
++  }
++
++  return { name: "npm" };
+ }
+ async function getTokenIsRequired() {
+   const {
+@@ -733,6 +756,9 @@ async function internalPublish(packageJson, opts, twoFactorState) {
+   } = publishTool.name === "pnpm" ? await spawn$1("pnpm", ["publish", "--json", ...publishFlags], {
+     env: Object.assign({}, process.env, envOverride),
+     cwd: opts.cwd
++  }) : publishTool.name === "yarn" ? await spawn$1("yarn", ["publish", "--json", ...publishFlags], {
++    env: Object.assign({}, process.env, envOverride),
++    cwd: opts.cwd
+   }) : await spawn$1(publishTool.name, ["publish", opts.publishDir, "--json", ...publishFlags], {
+     env: Object.assign({}, process.env, envOverride)
+   });

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:nobuild": "yarn workspaces foreach -Ap --exclude root run test --watch=false"
   },
   "devDependencies": {
-    "@changesets/cli": "^2.29.6",
+    "@changesets/cli": "patch:@changesets/cli@npm%3A2.29.6#~/.yarn/patches/@changesets-cli-npm-2.29.6-ac8361deb8.patch",
     "@typescript-eslint/eslint-plugin": "^5.39.0",
     "@typescript-eslint/parser": "^5.39.0",
     "eslint": "^8.24.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1512,7 +1512,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@changesets/cli@npm:^2.29.6":
+"@changesets/cli@npm:2.29.6":
   version: 2.29.6
   resolution: "@changesets/cli@npm:2.29.6"
   dependencies:
@@ -1547,6 +1547,44 @@ __metadata:
   bin:
     changeset: bin.js
   checksum: 10/227b0eb68e14ec88d107bf3652f357034ff7667c510c3752dd6244cfcf1fb2be22c10f8183f944b4e52e55255cde5fcfb7a56e6e9a6427cef7574e4d84cafd14
+  languageName: node
+  linkType: hard
+
+"@changesets/cli@patch:@changesets/cli@npm%3A2.29.6#~/.yarn/patches/@changesets-cli-npm-2.29.6-ac8361deb8.patch":
+  version: 2.29.6
+  resolution: "@changesets/cli@patch:@changesets/cli@npm%3A2.29.6#~/.yarn/patches/@changesets-cli-npm-2.29.6-ac8361deb8.patch::version=2.29.6&hash=739a2b"
+  dependencies:
+    "@changesets/apply-release-plan": "npm:^7.0.12"
+    "@changesets/assemble-release-plan": "npm:^6.0.9"
+    "@changesets/changelog-git": "npm:^0.2.1"
+    "@changesets/config": "npm:^3.1.1"
+    "@changesets/errors": "npm:^0.2.0"
+    "@changesets/get-dependents-graph": "npm:^2.1.3"
+    "@changesets/get-release-plan": "npm:^4.0.13"
+    "@changesets/git": "npm:^3.0.4"
+    "@changesets/logger": "npm:^0.1.1"
+    "@changesets/pre": "npm:^2.0.2"
+    "@changesets/read": "npm:^0.6.5"
+    "@changesets/should-skip-package": "npm:^0.1.2"
+    "@changesets/types": "npm:^6.1.0"
+    "@changesets/write": "npm:^0.4.0"
+    "@inquirer/external-editor": "npm:^1.0.0"
+    "@manypkg/get-packages": "npm:^1.1.3"
+    ansi-colors: "npm:^4.1.3"
+    ci-info: "npm:^3.7.0"
+    enquirer: "npm:^2.4.1"
+    fs-extra: "npm:^7.0.1"
+    mri: "npm:^1.2.0"
+    p-limit: "npm:^2.2.0"
+    package-manager-detector: "npm:^0.2.0"
+    picocolors: "npm:^1.1.0"
+    resolve-from: "npm:^5.0.0"
+    semver: "npm:^7.5.3"
+    spawndamnit: "npm:^3.0.1"
+    term-size: "npm:^2.1.0"
+  bin:
+    changeset: bin.js
+  checksum: 10/6b969312b23ae6b7f4c93d0bf344f5ea96d1348111d7736104310e895cba2243763e5ccefa27d4738f6c5b556ee0128b0e4a5178002d09b163da6d1e2e907942
   languageName: node
   linkType: hard
 
@@ -6333,7 +6371,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root@workspace:."
   dependencies:
-    "@changesets/cli": "npm:^2.29.6"
+    "@changesets/cli": "patch:@changesets/cli@npm%3A2.29.6#~/.yarn/patches/@changesets-cli-npm-2.29.6-ac8361deb8.patch"
     "@typescript-eslint/eslint-plugin": "npm:^5.39.0"
     "@typescript-eslint/parser": "npm:^5.39.0"
     eslint: "npm:^8.24.0"


### PR DESCRIPTION
## Why

Changesets published monorepo packages with package.json unmodified, which is incorrect.

## What

Try https://github.com/changesets/changesets/pull/1560