### PR TITLE
Remove redundant packageManager decl

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,7 +26,6 @@
   },
   "author": "Masaki Hara <ackie.h.gmai@gmail.com>",
   "license": "MIT",
-  "packageManager": "yarn@3.2.3",
   "files": [
     "dist/**/*",
     "!dist/*.tsbuildinfo",

--- a/packages/connector-i18n-js/package.json
+++ b/packages/connector-i18n-js/package.json
@@ -26,7 +26,6 @@
   },
   "author": "Masaki Hara <ackie.h.gmai@gmail.com>",
   "license": "MIT",
-  "packageManager": "yarn@3.2.3",
   "files": [
     "dist/**/*",
     "!dist/*.tsbuildinfo",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,7 +26,6 @@
   },
   "author": "Masaki Hara <ackie.h.gmai@gmail.com>",
   "license": "MIT",
-  "packageManager": "yarn@3.2.3",
   "files": [
     "dist/**/*",
     "!dist/*.tsbuildinfo",

--- a/packages/dev-utils/package.json
+++ b/packages/dev-utils/package.json
@@ -27,7 +27,6 @@
   },
   "author": "Masaki Hara <ackie.h.gmai@gmail.com>",
   "license": "MIT",
-  "packageManager": "yarn@3.2.3",
   "files": [
     "dist/**/*",
     "!dist/*.tsbuildinfo",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -28,7 +28,6 @@
   },
   "author": "Masaki Hara <ackie.h.gmai@gmail.com>",
   "license": "MIT",
-  "packageManager": "yarn@3.2.3",
   "files": [
     "dist/**/*",
     "!dist/*.tsbuildinfo",

--- a/packages/react-context/package.json
+++ b/packages/react-context/package.json
@@ -16,7 +16,6 @@
   },
   "author": "Masaki Hara <ackie.h.gmai@gmail.com>",
   "license": "MIT",
-  "packageManager": "yarn@3.2.3",
   "files": [
     "index.js",
     "index.module.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -28,7 +28,6 @@
   },
   "author": "Masaki Hara <ackie.h.gmai@gmail.com>",
   "license": "MIT",
-  "packageManager": "yarn@3.2.3",
   "files": [
     "dist/**/*",
     "!dist/*.tsbuildinfo",

--- a/packages/tools-core/package.json
+++ b/packages/tools-core/package.json
@@ -26,7 +26,6 @@
   },
   "author": "Masaki Hara <ackie.h.gmai@gmail.com>",
   "license": "MIT",
-  "packageManager": "yarn@3.2.3",
   "files": [
     "dist/**/*",
     "!dist/*.tsbuildinfo",

--- a/packages/ts-plugin/package.json
+++ b/packages/ts-plugin/package.json
@@ -17,7 +17,6 @@
   },
   "author": "Masaki Hara <ackie.h.gmai@gmail.com>",
   "license": "MIT",
-  "packageManager": "yarn@3.2.3",
   "files": [
     "dist/**/*",
     "!dist/*.tsbuildinfo",


### PR DESCRIPTION
## Why

Only the top-level declaration is relevant.

## What

Remove unnecessary ones.