### PR TITLE
fix(eslint-plugin): recover default export compat

### DIFF
--- a/.changeset/calm-snakes-repeat.md
+++ b/.changeset/calm-snakes-repeat.md
@@ -1,0 +1,5 @@
+---
+"@hi18n/eslint-plugin": patch
+---
+
+fix(eslint-plugin): recover default export compat

--- a/packages/eslint-plugin/cjs/wrapper.d.ts
+++ b/packages/eslint-plugin/cjs/wrapper.d.ts
@@ -1,0 +1,3 @@
+import index = require("./dist/index.js");
+
+export = index.default;

--- a/packages/eslint-plugin/cjs/wrapper.js
+++ b/packages/eslint-plugin/cjs/wrapper.js
@@ -1,0 +1,3 @@
+const index = require("./dist/index.js");
+
+module.exports = index.default;

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -35,10 +35,10 @@
     "!src/**/*.test.ts"
   ],
   "type": "module",
-  "main": "./cjs/dist/index.js",
+  "main": "./cjs/wrapper.js",
   "exports": {
     ".": {
-      "require": "./cjs/dist/index.js",
+      "require": "./cjs/wrapper.js",
       "default": "./dist/index.js"
     },
     "./internal-rules": {


### PR DESCRIPTION
## Why

https://github.com/wantedly/hi18n/pull/205 changed how things are exported as eslint-plugin, but it broke its CJS consumer.

## What

Recover default export compatibility when require'd rather than imported.