### PR TITLE
chore(workflow): fix lockfile update when there is no change

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,8 @@ jobs:
         if: steps.changesets.outputs.pullRequestNumber
         run: |
           YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install
-          git add yarn.lock
-          git commit -m "ci: update lockfile"
-          git push origin HEAD:changeset-release/master --force
+          if ! git diff --quiet yarn.lock; then
+            git add yarn.lock
+            git commit -m "ci: update lockfile"
+            git push origin HEAD:changeset-release/master --force
+          fi


### PR DESCRIPTION
## Why

Action failed https://github.com/wantedly/hi18n/actions/runs/17460040555/job/49582374588

## What

Skip commit when there is no change in the workflow.