### PR TITLE
chore(deps): bump commander from v9 to v13

### DIFF
--- a/.changeset/smart-zebras-love.md
+++ b/.changeset/smart-zebras-love.md
@@ -1,0 +1,5 @@
+---
+"@hi18n/cli": patch
+---
+
+chore(deps): bump commander from v9 to v13

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -56,7 +56,7 @@
     "@hi18n/tools-core": "^0.1.6",
     "@typescript-eslint/parser": "^8.42.0",
     "@typescript-eslint/utils": "^8.42.0",
-    "commander": "^9.2.0",
+    "commander": "^13.1.0",
     "cosmiconfig": "^7.0.1",
     "eslint": "^9.34.0",
     "glob": "^10.4.5",

--- a/packages/dev-utils/package.json
+++ b/packages/dev-utils/package.json
@@ -49,7 +49,7 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "commander": "^9.2.0",
+    "commander": "^13.1.0",
     "fs-extra": "^11.0.0",
     "glob": "^10.4.5"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -657,7 +657,7 @@ __metadata:
     "@types/resolve": "npm:^1.20.6"
     "@typescript-eslint/parser": "npm:^8.42.0"
     "@typescript-eslint/utils": "npm:^8.42.0"
-    commander: "npm:^9.2.0"
+    commander: "npm:^13.1.0"
     cosmiconfig: "npm:^7.0.1"
     eslint: "npm:^9.34.0"
     glob: "npm:^10.4.5"
@@ -702,7 +702,7 @@ __metadata:
   resolution: "@hi18n/dev-utils@workspace:packages/dev-utils"
   dependencies:
     "@types/fs-extra": "npm:^11.0.4"
-    commander: "npm:^9.2.0"
+    commander: "npm:^13.1.0"
     fs-extra: "npm:^11.0.0"
     glob: "npm:^10.4.5"
     rimraf: "npm:^3.0.2"
@@ -2006,10 +2006,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:^9.2.0":
-  version: 9.2.0
-  resolution: "commander@npm:9.2.0"
-  checksum: 10/db4855c6cd7694d4117e17ec353c7fcc678695e008e12dd5cd45ebaf3fd15607a476df690bf658c7a20a661743580fb0150c825087d773847a24392891e7b4bc
+"commander@npm:^13.1.0":
+  version: 13.1.0
+  resolution: "commander@npm:13.1.0"
+  checksum: 10/d3b4b79e6be8471ddadacbb8cd441fe82154d7da7393b50e76165a9e29ccdb74fa911a186437b9a211d0fc071db6051915c94fb8ef16d77511d898e9dbabc6af
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Why

## What

Update commander to v13. Not updating to v14 yet because v13 is said to drop support for Node.js 18.
