### PR TITLE
chore(ts): import ts files as *.ts

### DIFF
--- a/.changeset/open-readers-relax.md
+++ b/.changeset/open-readers-relax.md
@@ -1,0 +1,8 @@
+---
+"@hi18n/connector-i18n-js": patch
+"@hi18n/eslint-plugin": patch
+"@hi18n/core": patch
+"@hi18n/cli": patch
+---
+
+chore(ts): import ts files as \*.ts

--- a/packages/cli/src/__fixtures__/extension-removal/expect-sync/src/index.ts
+++ b/packages/cli/src/__fixtures__/extension-removal/expect-sync/src/index.ts
@@ -1,6 +1,6 @@
 import { getTranslator, translationId } from "@hi18n/core";
 // Intentionally having .js extension
-import { book } from "./locale/index.js";
+import { book } from "./locale/index.ts";
 
 const { t } = getTranslator(book, "ja");
 t("example/greeting");

--- a/packages/cli/src/__fixtures__/extension-removal/expect-sync/src/locale/index.ts
+++ b/packages/cli/src/__fixtures__/extension-removal/expect-sync/src/locale/index.ts
@@ -1,8 +1,8 @@
 import { Message, Book } from "@hi18n/core";
 // Intentionally having .js extension
-import catalogEn from "./en.js";
+import catalogEn from "./en.ts";
 // Intentionally having .js extension
-import catalogJa from "./ja.js";
+import catalogJa from "./ja.ts";
 
 export type Vocabulary = {
   "example/dynamic-todo": Message;

--- a/packages/cli/src/__fixtures__/extension-removal/input/src/index.ts
+++ b/packages/cli/src/__fixtures__/extension-removal/input/src/index.ts
@@ -1,6 +1,6 @@
 import { getTranslator, translationId } from "@hi18n/core";
 // Intentionally having .js extension
-import { book } from "./locale/index.js";
+import { book } from "./locale/index.ts";
 
 const { t } = getTranslator(book, "ja");
 t("example/greeting");

--- a/packages/cli/src/__fixtures__/extension-removal/input/src/locale/index.ts
+++ b/packages/cli/src/__fixtures__/extension-removal/input/src/locale/index.ts
@@ -1,8 +1,8 @@
 import { Message, Book } from "@hi18n/core";
 // Intentionally having .js extension
-import catalogEn from "./en.js";
+import catalogEn from "./en.ts";
 // Intentionally having .js extension
-import catalogJa from "./ja.js";
+import catalogJa from "./ja.ts";
 
 export type Vocabulary = {
   "example/greeting": Message;

--- a/packages/cli/src/command.ts
+++ b/packages/cli/src/command.ts
@@ -1,6 +1,6 @@
 import { Command, type OutputConfiguration } from "commander";
-import { export_ } from "./export.js";
-import { sync } from "./sync.js";
+import { export_ } from "./export.ts";
+import { sync } from "./sync.ts";
 
 export async function hi18n(
   argv?: readonly string[],

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -7,7 +7,7 @@ import {
 } from "@typescript-eslint/utils";
 import resolve from "resolve";
 import type { Connector } from "@hi18n/tools-core";
-import * as jsonMfConnector from "./json-mf-connector.js";
+import * as jsonMfConnector from "./json-mf-connector.ts";
 
 const explorer = cosmiconfig("hi18n");
 

--- a/packages/cli/src/export.test.ts
+++ b/packages/cli/src/export.test.ts
@@ -1,5 +1,5 @@
 import { describe, it } from "vitest";
-import { hi18n } from "./command.js";
+import { hi18n } from "./command.ts";
 import { MockedOutput, initFixtures } from "@hi18n/dev-utils";
 
 const { withProject } = initFixtures(__dirname);

--- a/packages/cli/src/export.ts
+++ b/packages/cli/src/export.ts
@@ -6,7 +6,7 @@ import {
   getCollectCatalogDefinitionsRule,
   type CatalogDef,
 } from "@hi18n/eslint-plugin/internal-rules";
-import { loadConfig } from "./config.js";
+import { loadConfig } from "./config.ts";
 import type { Hi18nCatalogData } from "@hi18n/tools-core";
 
 export type Options = {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,4 +1,4 @@
-import { hi18n } from "./command.js";
+import { hi18n } from "./command.ts";
 
 const result = hi18n();
 result.catch((e) => {

--- a/packages/cli/src/sync.test.ts
+++ b/packages/cli/src/sync.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { hi18n } from "./command.js";
+import { hi18n } from "./command.ts";
 import { MockedOutput, initFixtures } from "@hi18n/dev-utils";
 
 const { withProject } = initFixtures(__dirname);

--- a/packages/cli/src/sync.ts
+++ b/packages/cli/src/sync.ts
@@ -17,7 +17,7 @@ import {
   type CatalogDef,
   type TranslationUsage,
 } from "@hi18n/eslint-plugin/internal-rules";
-import { loadConfig } from "./config.js";
+import { loadConfig } from "./config.ts";
 
 export type Options = {
   cwd: string;

--- a/packages/connector-i18n-js/src/index.test.ts
+++ b/packages/connector-i18n-js/src/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import path from "node:path";
-import { connector } from "./index.js";
+import { connector } from "./index.ts";
 
 describe("importData", () => {
   it("imports data from config/locales", async () => {

--- a/packages/connector-i18n-js/src/index.ts
+++ b/packages/connector-i18n-js/src/index.ts
@@ -7,7 +7,7 @@ import type {
   Hi18nCatalogData,
   ConnectorObj,
 } from "@hi18n/tools-core";
-import { convertMessage, isMessage } from "./message.js";
+import { convertMessage, isMessage } from "./message.ts";
 
 export function connector(configPath: string, params: unknown): ConnectorObj {
   const { root: relativeRoot = ".", include = ["config/locales/*.yml"] } =

--- a/packages/connector-i18n-js/src/message.test.ts
+++ b/packages/connector-i18n-js/src/message.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { convertMessage } from "./message.js";
+import { convertMessage } from "./message.ts";
 
 describe("convertMessage", () => {
   it("converts a simple message", () => {

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -16,7 +16,7 @@ import {
   MessageEvaluationError,
   MissingTranslationError,
   preloadCatalogs,
-} from "./index.js";
+} from "./index.ts";
 
 const nodeVersion = (globalThis as unknown as { process: { version: string } })
   .process.version;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,27 +1,27 @@
 /* eslint-disable @typescript-eslint/no-empty-object-type, @typescript-eslint/no-explicit-any */
 
-import type { CompiledMessage } from "./msgfmt.js";
-import { type EvalOption, evaluateMessage } from "./msgfmt-eval.js";
-import { parseMessage } from "./msgfmt-parser.js";
+import type { CompiledMessage } from "./msgfmt.ts";
+import { type EvalOption, evaluateMessage } from "./msgfmt-eval.ts";
+import { parseMessage } from "./msgfmt-parser.ts";
 import type {
   ComponentPlaceholder,
   InferredMessageType,
-} from "./msgfmt-parser-types.js";
+} from "./msgfmt-parser-types.ts";
 import {
   MessageError,
   MissingLocaleError,
   MissingTranslationError,
   NoLocaleError,
-} from "./errors.js";
+} from "./errors.ts";
 import {
   defaultErrorHandler,
   type ErrorHandler,
   type ErrorLevel,
-} from "./error-handling.js";
+} from "./error-handling.ts";
 
-export type { ComponentPlaceholder } from "./msgfmt-parser-types.js";
-export * from "./errors.js";
-export * from "./error-handling.js";
+export type { ComponentPlaceholder } from "./msgfmt-parser-types.ts";
+export * from "./errors.ts";
+export * from "./error-handling.ts";
 
 declare const messageBrandSymbol: unique symbol;
 declare const translationIdBrandSymbol: unique symbol;

--- a/packages/core/src/msgfmt-eval.test.ts
+++ b/packages/core/src/msgfmt-eval.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vitest } from "vitest";
-import type { CompiledMessage } from "./msgfmt.js";
-import { evaluateMessage } from "./msgfmt-eval.js";
-import type { ErrorHandler } from "./error-handling.js";
+import type { CompiledMessage } from "./msgfmt.ts";
+import { evaluateMessage } from "./msgfmt-eval.ts";
+import type { ErrorHandler } from "./error-handling.ts";
 
 describe("evaluageMessage", () => {
   it("evaluates a string", () => {

--- a/packages/core/src/msgfmt-eval.ts
+++ b/packages/core/src/msgfmt-eval.ts
@@ -1,10 +1,10 @@
-import { defaultErrorHandler, type ErrorHandler } from "./error-handling.js";
+import { defaultErrorHandler, type ErrorHandler } from "./error-handling.ts";
 import {
   ArgumentTypeError,
   MessageEvaluationError,
   MissingArgumentError,
-} from "./errors.js";
-import type { CompiledMessage } from "./msgfmt.js";
+} from "./errors.ts";
+import type { CompiledMessage } from "./msgfmt.ts";
 
 export type EvalOption<T> = {
   id?: string | undefined;

--- a/packages/core/src/msgfmt-parser-types.test.ts
+++ b/packages/core/src/msgfmt-parser-types.test.ts
@@ -1,12 +1,12 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 
 import { describe, it } from "vitest";
-import type { Message } from "./index.js";
+import type { Message } from "./index.ts";
 import type {
   ComponentPlaceholder,
   InferredMessageType,
   ParseError,
-} from "./msgfmt-parser-types.js";
+} from "./msgfmt-parser-types.ts";
 
 describe("InferredMessageType", () => {
   it("infers no arguments", () => {

--- a/packages/core/src/msgfmt-parser-types.ts
+++ b/packages/core/src/msgfmt-parser-types.ts
@@ -2,7 +2,7 @@
 
 // The parser algorithm is written to vastly match what is implemented in ./msgfmt-parser.ts, but with a few differences.
 
-import type { Message } from "./index.js";
+import type { Message } from "./index.ts";
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 declare const componentPlaceholderSymbol: unique symbol;

--- a/packages/core/src/msgfmt-parser.test.ts
+++ b/packages/core/src/msgfmt-parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseMessage } from "./msgfmt-parser.js";
+import { parseMessage } from "./msgfmt-parser.ts";
 
 describe("parseMessage", () => {
   it("parses plain texts", () => {

--- a/packages/core/src/msgfmt-parser.ts
+++ b/packages/core/src/msgfmt-parser.ts
@@ -1,4 +1,4 @@
-import { ParseError } from "./errors.js";
+import { ParseError } from "./errors.ts";
 import type {
   ArgType,
   CompiledMessage,
@@ -6,7 +6,7 @@ import type {
   PluralArg,
   PluralBranch,
   VarArg,
-} from "./msgfmt.js";
+} from "./msgfmt.ts";
 
 const SIMPLE_MESSAGE = /^[^'{}<]*$/;
 

--- a/packages/eslint-plugin/cjs/wrapper.d.ts
+++ b/packages/eslint-plugin/cjs/wrapper.d.ts
@@ -8,4 +8,4 @@ export type {
   Config,
   LegacyConfig,
   SharedConfigs,
-} from "./dist/index.js";
+} from "./dist/index.ts";

--- a/packages/eslint-plugin/src/book-util.ts
+++ b/packages/eslint-plugin/src/book-util.ts
@@ -1,5 +1,5 @@
 import { TSESLint, TSESTree } from "@typescript-eslint/utils";
-import { type DefReference, lookupDefinitionSource } from "./def-location.js";
+import { type DefReference, lookupDefinitionSource } from "./def-location.ts";
 
 export function getCatalogRef(
   scopeManager: TSESLint.Scope.ScopeManager,

--- a/packages/eslint-plugin/src/common-trackers.ts
+++ b/packages/eslint-plugin/src/common-trackers.ts
@@ -1,4 +1,4 @@
-import { type CaptureMap, type GeneralizedNode, Tracker } from "./tracker.js";
+import { type CaptureMap, type GeneralizedNode, Tracker } from "./tracker.ts";
 
 export function bookTracker(): Tracker {
   const tracker = new Tracker();

--- a/packages/eslint-plugin/src/def-location.ts
+++ b/packages/eslint-plugin/src/def-location.ts
@@ -1,5 +1,5 @@
 import { TSESLint, TSESTree } from "@typescript-eslint/utils";
-import { getImportName, nameOf, resolveVariable } from "./util.js";
+import { getImportName, nameOf, resolveVariable } from "./util.ts";
 
 export type DefLocation = {
   path: string;

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,10 +1,10 @@
 import type { TSESLint } from "@typescript-eslint/utils";
-import { rule as ruleMigrateFromLingui } from "./rules/migrate-from-lingui.js";
-import { rule as ruleNoDynamicTranslationIds } from "./rules/no-dynamic-translation-ids.js";
-import { rule as ruleReactComponentParams } from "./rules/react-component-params.js";
-import { rule as ruleWellFormedBookDefinitions } from "./rules/well-formed-book-definitions.js";
-import { rule as ruleWellFormedBookReferences } from "./rules/well-formed-book-references.js";
-import { rule as ruleWellFormedCatalogDefinitions } from "./rules/well-formed-catalog-definitions.js";
+import { rule as ruleMigrateFromLingui } from "./rules/migrate-from-lingui.ts";
+import { rule as ruleNoDynamicTranslationIds } from "./rules/no-dynamic-translation-ids.ts";
+import { rule as ruleReactComponentParams } from "./rules/react-component-params.ts";
+import { rule as ruleWellFormedBookDefinitions } from "./rules/well-formed-book-definitions.ts";
+import { rule as ruleWellFormedBookReferences } from "./rules/well-formed-book-references.ts";
+import { rule as ruleWellFormedCatalogDefinitions } from "./rules/well-formed-catalog-definitions.ts";
 import type { ESLint, Linter } from "eslint";
 
 export type Plugin = TSESLint.FlatConfig.Plugin &

--- a/packages/eslint-plugin/src/internal-rules.ts
+++ b/packages/eslint-plugin/src/internal-rules.ts
@@ -1,13 +1,13 @@
-export { getRule as getCollectBookDefinitionsRule } from "./rules/collect-book-definitions.js";
-export { getRule as getCollectCatalogDefinitionsRule } from "./rules/collect-catalog-definitions.js";
-export { getRule as getCollectTranslationIdsRule } from "./rules/collect-translation-ids.js";
-export { rule as noMissingTranslationIdsRule } from "./rules/no-missing-translation-ids.js";
-export { rule as noMissingTranslationIdsInTypesRule } from "./rules/no-missing-translation-ids-in-types.js";
-export { rule as noUnusedTranslationIdsRule } from "./rules/no-unused-translation-ids.js";
-export { rule as noUnusedTranslationIdsInTypesRule } from "./rules/no-unused-translation-ids-in-types.js";
+export { getRule as getCollectBookDefinitionsRule } from "./rules/collect-book-definitions.ts";
+export { getRule as getCollectCatalogDefinitionsRule } from "./rules/collect-catalog-definitions.ts";
+export { getRule as getCollectTranslationIdsRule } from "./rules/collect-translation-ids.ts";
+export { rule as noMissingTranslationIdsRule } from "./rules/no-missing-translation-ids.ts";
+export { rule as noMissingTranslationIdsInTypesRule } from "./rules/no-missing-translation-ids-in-types.ts";
+export { rule as noUnusedTranslationIdsRule } from "./rules/no-unused-translation-ids.ts";
+export { rule as noUnusedTranslationIdsInTypesRule } from "./rules/no-unused-translation-ids-in-types.ts";
 
-export { serializedLocations, serializeReference } from "./def-location.js";
-export type { DefLocation, DefReference } from "./def-location.js";
-export type { BookDef, CatalogLink } from "./rules/collect-book-definitions.js";
-export type { CatalogDef } from "./rules/collect-catalog-definitions.js";
-export type { TranslationUsage } from "./rules/collect-translation-ids.js";
+export { serializedLocations, serializeReference } from "./def-location.ts";
+export type { DefLocation, DefReference } from "./def-location.ts";
+export type { BookDef, CatalogLink } from "./rules/collect-book-definitions.ts";
+export type { CatalogDef } from "./rules/collect-catalog-definitions.ts";
+export type { TranslationUsage } from "./rules/collect-translation-ids.ts";

--- a/packages/eslint-plugin/src/microparser.test.ts
+++ b/packages/eslint-plugin/src/microparser.test.ts
@@ -4,7 +4,7 @@ import {
   isTSSignature,
   ParseError,
   tokenize,
-} from "./microparser.js";
+} from "./microparser.ts";
 
 describe("isProperty", () => {
   it("parses a property", () => {

--- a/packages/eslint-plugin/src/rules/collect-book-definitions.test.ts
+++ b/packages/eslint-plugin/src/rules/collect-book-definitions.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { TSESLint } from "@typescript-eslint/utils";
-import { type BookDef, getRule } from "./collect-book-definitions.js";
+import { type BookDef, getRule } from "./collect-book-definitions.ts";
 
 function getConfig(collected: BookDef[]): TSESLint.FlatConfig.Config {
   return {

--- a/packages/eslint-plugin/src/rules/collect-book-definitions.ts
+++ b/packages/eslint-plugin/src/rules/collect-book-definitions.ts
@@ -1,12 +1,12 @@
 import type { TSESLint, TSESTree } from "@typescript-eslint/utils";
-import { getStaticKey } from "../util.js";
-import { bookTracker } from "../common-trackers.js";
+import { getStaticKey } from "../util.ts";
+import { bookTracker } from "../common-trackers.ts";
 import {
   type DefLocation,
   type DefReference,
   resolveAsLocation,
-} from "../def-location.js";
-import { getCatalogRef } from "../book-util.js";
+} from "../def-location.ts";
+import { getCatalogRef } from "../book-util.ts";
 import { createRule, type PluginDocs } from "./create-rule.ts";
 
 export type BookDef = {

--- a/packages/eslint-plugin/src/rules/collect-catalog-definitions.test.ts
+++ b/packages/eslint-plugin/src/rules/collect-catalog-definitions.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { TSESLint } from "@typescript-eslint/utils";
-import { type CatalogDef, getRule } from "./collect-catalog-definitions.js";
+import { type CatalogDef, getRule } from "./collect-catalog-definitions.ts";
 
 function getConfig(
   collected: CatalogDef[],

--- a/packages/eslint-plugin/src/rules/collect-catalog-definitions.ts
+++ b/packages/eslint-plugin/src/rules/collect-catalog-definitions.ts
@@ -1,8 +1,8 @@
 import type { TSESLint } from "@typescript-eslint/utils";
-import { catalogTracker, getCatalogData } from "../common-trackers.js";
-import { type DefLocation, resolveAsLocation } from "../def-location.js";
-import { type CaptureMap } from "../tracker.js";
-import { getStaticKey } from "../util.js";
+import { catalogTracker, getCatalogData } from "../common-trackers.ts";
+import { type DefLocation, resolveAsLocation } from "../def-location.ts";
+import { type CaptureMap } from "../tracker.ts";
+import { getStaticKey } from "../util.ts";
 import { createRule, type PluginDocs } from "./create-rule.ts";
 
 export type CatalogDef = {

--- a/packages/eslint-plugin/src/rules/collect-translation-ids.test.ts
+++ b/packages/eslint-plugin/src/rules/collect-translation-ids.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { TSESLint } from "@typescript-eslint/utils";
-import { type TranslationUsage, getRule } from "./collect-translation-ids.js";
+import { type TranslationUsage, getRule } from "./collect-translation-ids.ts";
 
 function getConfig(collected: TranslationUsage[]): TSESLint.FlatConfig.Config {
   return {

--- a/packages/eslint-plugin/src/rules/collect-translation-ids.ts
+++ b/packages/eslint-plugin/src/rules/collect-translation-ids.ts
@@ -1,6 +1,6 @@
 import type { TSESLint } from "@typescript-eslint/utils";
-import { translationCallTracker } from "../common-trackers.js";
-import { type DefReference, lookupDefinitionSource } from "../def-location.js";
+import { translationCallTracker } from "../common-trackers.ts";
+import { type DefReference, lookupDefinitionSource } from "../def-location.ts";
 import { createRule, type PluginDocs } from "./create-rule.ts";
 
 export type TranslationUsage = {

--- a/packages/eslint-plugin/src/rules/migrate-from-lingui.test.ts
+++ b/packages/eslint-plugin/src/rules/migrate-from-lingui.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, describe, it } from "vitest";
 import * as espree from "espree";
 import { RuleTester } from "@typescript-eslint/rule-tester";
-import { rule } from "./migrate-from-lingui.js";
+import { rule } from "./migrate-from-lingui.ts";
 
 RuleTester.afterAll = afterAll;
 RuleTester.describe = describe;

--- a/packages/eslint-plugin/src/rules/migrate-from-lingui.ts
+++ b/packages/eslint-plugin/src/rules/migrate-from-lingui.ts
@@ -1,8 +1,8 @@
 import path from "node:path";
 import type { TSESLint, TSESTree } from "@typescript-eslint/utils";
-import { linguiTracker } from "../common-trackers.js";
-import { capturedRoot } from "../tracker.js";
-import { getStaticKey, nameOf } from "../util.js";
+import { linguiTracker } from "../common-trackers.ts";
+import { capturedRoot } from "../tracker.ts";
+import { getStaticKey, nameOf } from "../util.ts";
 import { createRule, type PluginDocs } from "./create-rule.ts";
 
 type MessageIds = "migrate-trans-jsx" | "migrate-underscore";

--- a/packages/eslint-plugin/src/rules/no-dynamic-translation-ids.test.ts
+++ b/packages/eslint-plugin/src/rules/no-dynamic-translation-ids.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, describe, it } from "vitest";
 import * as espree from "espree";
 import { RuleTester } from "@typescript-eslint/rule-tester";
-import { rule } from "./no-dynamic-translation-ids.js";
+import { rule } from "./no-dynamic-translation-ids.ts";
 
 RuleTester.afterAll = afterAll;
 RuleTester.describe = describe;

--- a/packages/eslint-plugin/src/rules/no-dynamic-translation-ids.ts
+++ b/packages/eslint-plugin/src/rules/no-dynamic-translation-ids.ts
@@ -1,6 +1,6 @@
 import type { TSESLint } from "@typescript-eslint/utils";
-import { translationCallTracker } from "../common-trackers.js";
-import { capturedRoot } from "../tracker.js";
+import { translationCallTracker } from "../common-trackers.ts";
+import { capturedRoot } from "../tracker.ts";
 import { createRule, type PluginDocs } from "./create-rule.ts";
 
 type MessageIds = "no-dynamic-keys";

--- a/packages/eslint-plugin/src/rules/no-missing-translation-ids-in-types.test.ts
+++ b/packages/eslint-plugin/src/rules/no-missing-translation-ids-in-types.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, describe, it } from "vitest";
 import * as tsParser from "@typescript-eslint/parser";
 import { RuleTester } from "@typescript-eslint/rule-tester";
-import { rule } from "./no-missing-translation-ids-in-types.js";
+import { rule } from "./no-missing-translation-ids-in-types.ts";
 
 RuleTester.afterAll = afterAll;
 RuleTester.describe = describe;

--- a/packages/eslint-plugin/src/rules/no-missing-translation-ids-in-types.ts
+++ b/packages/eslint-plugin/src/rules/no-missing-translation-ids-in-types.ts
@@ -1,9 +1,9 @@
 import type { TSESLint, TSESTree } from "@typescript-eslint/utils";
-import { getStaticKey, lineIndent } from "../util.js";
-import { bookTracker } from "../common-trackers.js";
-import { findTypeDefinition } from "../ts-util.js";
-import { parseComments, ParseError, Parser } from "../microparser.js";
-import { queryUsedTranslationIds } from "../used-ids.js";
+import { getStaticKey, lineIndent } from "../util.ts";
+import { bookTracker } from "../common-trackers.ts";
+import { findTypeDefinition } from "../ts-util.ts";
+import { parseComments, ParseError, Parser } from "../microparser.ts";
+import { queryUsedTranslationIds } from "../used-ids.ts";
 import { createRule, type PluginDocs } from "./create-rule.ts";
 
 type MessageIds = "missing-translation-ids";

--- a/packages/eslint-plugin/src/rules/no-missing-translation-ids.test.ts
+++ b/packages/eslint-plugin/src/rules/no-missing-translation-ids.test.ts
@@ -2,7 +2,7 @@ import { afterAll, describe, it } from "vitest";
 import * as espree from "espree";
 import * as tsParser from "@typescript-eslint/parser";
 import { RuleTester } from "@typescript-eslint/rule-tester";
-import { rule } from "./no-missing-translation-ids.js";
+import { rule } from "./no-missing-translation-ids.ts";
 
 RuleTester.afterAll = afterAll;
 RuleTester.describe = describe;

--- a/packages/eslint-plugin/src/rules/no-missing-translation-ids.ts
+++ b/packages/eslint-plugin/src/rules/no-missing-translation-ids.ts
@@ -1,8 +1,8 @@
 import type { TSESLint, TSESTree } from "@typescript-eslint/utils";
-import { getStaticKey, lineIndent } from "../util.js";
-import { catalogTracker, getCatalogData } from "../common-trackers.js";
-import { parseComments, ParseError, Parser } from "../microparser.js";
-import { queryUsedTranslationIds } from "../used-ids.js";
+import { getStaticKey, lineIndent } from "../util.ts";
+import { catalogTracker, getCatalogData } from "../common-trackers.ts";
+import { parseComments, ParseError, Parser } from "../microparser.ts";
+import { queryUsedTranslationIds } from "../used-ids.ts";
 import { createRule, type PluginDocs } from "./create-rule.ts";
 
 type MessageIds = "missing-translation-ids";

--- a/packages/eslint-plugin/src/rules/no-unused-translation-ids-in-types.test.ts
+++ b/packages/eslint-plugin/src/rules/no-unused-translation-ids-in-types.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, describe, it } from "vitest";
 import * as tsParser from "@typescript-eslint/parser";
 import { RuleTester } from "@typescript-eslint/rule-tester";
-import { rule } from "./no-unused-translation-ids-in-types.js";
+import { rule } from "./no-unused-translation-ids-in-types.ts";
 
 RuleTester.afterAll = afterAll;
 RuleTester.describe = describe;

--- a/packages/eslint-plugin/src/rules/no-unused-translation-ids-in-types.ts
+++ b/packages/eslint-plugin/src/rules/no-unused-translation-ids-in-types.ts
@@ -1,8 +1,8 @@
 import type { TSESLint } from "@typescript-eslint/utils";
-import { commentOut, getStaticKey } from "../util.js";
-import { findTypeDefinition } from "../ts-util.js";
-import { bookTracker } from "../common-trackers.js";
-import { queryUsedTranslationIds } from "../used-ids.js";
+import { commentOut, getStaticKey } from "../util.ts";
+import { findTypeDefinition } from "../ts-util.ts";
+import { bookTracker } from "../common-trackers.ts";
+import { queryUsedTranslationIds } from "../used-ids.ts";
 import { createRule, type PluginDocs } from "./create-rule.ts";
 
 type MessageIds = "unused-translation-id";

--- a/packages/eslint-plugin/src/rules/no-unused-translation-ids.test.ts
+++ b/packages/eslint-plugin/src/rules/no-unused-translation-ids.test.ts
@@ -2,7 +2,7 @@ import { afterAll, describe, it } from "vitest";
 import * as espree from "espree";
 import * as tsParser from "@typescript-eslint/parser";
 import { RuleTester } from "@typescript-eslint/rule-tester";
-import { rule } from "./no-unused-translation-ids.js";
+import { rule } from "./no-unused-translation-ids.ts";
 
 RuleTester.afterAll = afterAll;
 RuleTester.describe = describe;

--- a/packages/eslint-plugin/src/rules/no-unused-translation-ids.ts
+++ b/packages/eslint-plugin/src/rules/no-unused-translation-ids.ts
@@ -1,7 +1,7 @@
 import type { TSESLint } from "@typescript-eslint/utils";
-import { commentOut, getStaticKey } from "../util.js";
-import { catalogTracker, getCatalogData } from "../common-trackers.js";
-import { queryUsedTranslationIds } from "../used-ids.js";
+import { commentOut, getStaticKey } from "../util.ts";
+import { catalogTracker, getCatalogData } from "../common-trackers.ts";
+import { queryUsedTranslationIds } from "../used-ids.ts";
 import { createRule, type PluginDocs } from "./create-rule.ts";
 
 type MessageIds = "unused-translation-id";

--- a/packages/eslint-plugin/src/rules/react-component-params.test.ts
+++ b/packages/eslint-plugin/src/rules/react-component-params.test.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import { afterAll, describe, it } from "vitest";
 import * as tsParser from "@typescript-eslint/parser";
 import { RuleTester } from "@typescript-eslint/rule-tester";
-import { rule } from "./react-component-params.js";
+import { rule } from "./react-component-params.ts";
 
 RuleTester.afterAll = afterAll;
 RuleTester.describe = describe;

--- a/packages/eslint-plugin/src/rules/react-component-params.ts
+++ b/packages/eslint-plugin/src/rules/react-component-params.ts
@@ -1,6 +1,6 @@
 import { ESLintUtils, TSESTree, type TSESLint } from "@typescript-eslint/utils";
 import * as ts from "typescript";
-import { translationCallTracker } from "../common-trackers.js";
+import { translationCallTracker } from "../common-trackers.ts";
 import { createRule, type PluginDocs } from "./create-rule.ts";
 
 type MessageIds =

--- a/packages/eslint-plugin/src/rules/well-formed-book-definitions.test.ts
+++ b/packages/eslint-plugin/src/rules/well-formed-book-definitions.test.ts
@@ -2,7 +2,7 @@ import { afterAll, describe, it } from "vitest";
 import * as espree from "espree";
 import * as tsParser from "@typescript-eslint/parser";
 import { RuleTester } from "@typescript-eslint/rule-tester";
-import { rule } from "./well-formed-book-definitions.js";
+import { rule } from "./well-formed-book-definitions.ts";
 
 RuleTester.afterAll = afterAll;
 RuleTester.describe = describe;

--- a/packages/eslint-plugin/src/rules/well-formed-book-definitions.ts
+++ b/packages/eslint-plugin/src/rules/well-formed-book-definitions.ts
@@ -1,14 +1,14 @@
 import type { TSESLint, TSESTree } from "@typescript-eslint/utils";
-import { getStaticKey } from "../util.js";
+import { getStaticKey } from "../util.ts";
 import {
   extractAsObjectType,
   findTypeParameter,
   resolveTypeLevelVariable,
-} from "../ts-util.js";
-import { bookTracker } from "../common-trackers.js";
-import { capturedRoot } from "../tracker.js";
-import { resolveAsLocation } from "../def-location.js";
-import { getCatalogRef } from "../book-util.js";
+} from "../ts-util.ts";
+import { bookTracker } from "../common-trackers.ts";
+import { capturedRoot } from "../tracker.ts";
+import { resolveAsLocation } from "../def-location.ts";
+import { getCatalogRef } from "../book-util.ts";
 import { createRule, type PluginDocs } from "./create-rule.ts";
 
 type MessageIds =

--- a/packages/eslint-plugin/src/rules/well-formed-book-references.test.ts
+++ b/packages/eslint-plugin/src/rules/well-formed-book-references.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, describe, it } from "vitest";
 import * as espree from "espree";
 import { RuleTester } from "@typescript-eslint/rule-tester";
-import { rule } from "./well-formed-book-references.js";
+import { rule } from "./well-formed-book-references.ts";
 
 RuleTester.afterAll = afterAll;
 RuleTester.describe = describe;

--- a/packages/eslint-plugin/src/rules/well-formed-book-references.ts
+++ b/packages/eslint-plugin/src/rules/well-formed-book-references.ts
@@ -1,7 +1,7 @@
 import type { TSESLint } from "@typescript-eslint/utils";
-import { translationCallTracker } from "../common-trackers.js";
-import { lookupDefinitionSource } from "../def-location.js";
-import { capturedRoot } from "../tracker.js";
+import { translationCallTracker } from "../common-trackers.ts";
+import { lookupDefinitionSource } from "../def-location.ts";
+import { capturedRoot } from "../tracker.ts";
 import { createRule, type PluginDocs } from "./create-rule.ts";
 
 type MessageIds = "clarify-book-reference";

--- a/packages/eslint-plugin/src/rules/well-formed-catalog-definitions.test.ts
+++ b/packages/eslint-plugin/src/rules/well-formed-catalog-definitions.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, describe, it } from "vitest";
 import * as espree from "espree";
 import { RuleTester } from "@typescript-eslint/rule-tester";
-import { rule } from "./well-formed-catalog-definitions.js";
+import { rule } from "./well-formed-catalog-definitions.ts";
 
 RuleTester.afterAll = afterAll;
 RuleTester.describe = describe;

--- a/packages/eslint-plugin/src/rules/well-formed-catalog-definitions.ts
+++ b/packages/eslint-plugin/src/rules/well-formed-catalog-definitions.ts
@@ -1,8 +1,8 @@
 import type { TSESLint } from "@typescript-eslint/utils";
-import { getStaticKey } from "../util.js";
-import { catalogTracker, getCatalogData } from "../common-trackers.js";
-import { capturedRoot } from "../tracker.js";
-import { resolveAsLocation } from "../def-location.js";
+import { getStaticKey } from "../util.ts";
+import { catalogTracker, getCatalogData } from "../common-trackers.ts";
+import { capturedRoot } from "../tracker.ts";
+import { resolveAsLocation } from "../def-location.ts";
 import { createRule, type PluginDocs } from "./create-rule.ts";
 
 type MessageIds =

--- a/packages/eslint-plugin/src/tracker.ts
+++ b/packages/eslint-plugin/src/tracker.ts
@@ -5,7 +5,7 @@ import {
   getStaticKey,
   getStaticMemKey,
   resolveVariable,
-} from "./util.js";
+} from "./util.ts";
 
 export class Tracker {
   watchingImports: Record<string, string[]> = {};

--- a/packages/eslint-plugin/src/ts-util.ts
+++ b/packages/eslint-plugin/src/ts-util.ts
@@ -1,5 +1,5 @@
 import type { TSESLint, TSESTree } from "@typescript-eslint/utils";
-import { nearestScope } from "./util.js";
+import { nearestScope } from "./util.ts";
 
 export type TypeDeclarator =
   | TSESTree.TSInterfaceDeclaration

--- a/packages/eslint-plugin/src/used-ids.ts
+++ b/packages/eslint-plugin/src/used-ids.ts
@@ -1,5 +1,5 @@
 import type { TSESLint, TSESTree } from "@typescript-eslint/utils";
-import { resolveAsLocation, serializedLocations } from "./def-location.js";
+import { resolveAsLocation, serializedLocations } from "./def-location.ts";
 
 export function queryUsedTranslationIds<
   TMessageIds extends string,

--- a/packages/react/src/index.test.tsx
+++ b/packages/react/src/index.test.tsx
@@ -15,7 +15,7 @@ import {
   translationId,
   type TranslatorObject,
 } from "@hi18n/core";
-import { LocaleProvider, Translate, useI18n, useLocales } from "./index.js";
+import { LocaleProvider, Translate, useI18n, useLocales } from "./index.tsx";
 import type { ComponentPlaceholder } from "@hi18n/core";
 import { LocaleContext } from "@hi18n/react-context";
 


### PR DESCRIPTION
## Why

As we configured allowImportingTsExtensions and rewriteRelativeImportExtensions in https://github.com/wantedly/hi18n/pull/203, we can now import ts files as `*.ts`.

Moreover, this is consistent with how Node.js would handle ts files with `--experimental-strip-types` landed and how Deno handles them.

## What

Import ts files as *.ts.