### PR TITLE
feat(core): require use of msg()

### DIFF
--- a/.changeset/shy-bobcats-know.md
+++ b/.changeset/shy-bobcats-know.md
@@ -1,0 +1,5 @@
+---
+"@hi18n/core": minor
+---
+
+feat(core): require use of msg()


### PR DESCRIPTION
## Why

We're planning to move away from MessageFormat and instead embed the structured message directly.

## What

To safely migrate from the current interface, require use of msg() in Catalog constructor. Internally it means that `msg()` wraps the string rather than behaving as a typed identity function.

Correctly typed uses of hi18n in TypeScript will not be affected in most cases.