### PR TITLE
fix(react)!: restrict key type

### DIFF
--- a/.changeset/poor-moose-yawn.md
+++ b/.changeset/poor-moose-yawn.md
@@ -1,0 +1,5 @@
+---
+"@hi18n/react": minor
+---
+
+fix(react)!: restrict key type

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -129,9 +129,7 @@ export function useI18n<M extends VocabularyBase>(
 
 export type BaseTranslateProps<
   Vocabulary extends VocabularyBase,
-  // TODO: restrict to string
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  K extends keyof any,
+  K extends string,
 > = {
   /**
    * The book to look up in for the translation.
@@ -178,8 +176,7 @@ export type BaseTranslateProps<
 
 export type TranslateProps<
   M extends VocabularyBase,
-  // TODO: restrict to string
-  K extends keyof M,
+  K extends keyof M & string,
 > = BaseTranslateProps<M, K> &
   PartialForComponents<MessageArguments<M[K], React.ReactElement>>;
 


### PR DESCRIPTION
## Why

Cleanup before v0.2.0.

## What

Slightly change key types so that they are restricted below `string`.