### PR TITLE
fix(react)!: change how locales are propagated

### DIFF
--- a/.changeset/three-boats-brake.md
+++ b/.changeset/three-boats-brake.md
@@ -1,0 +1,6 @@
+---
+"@hi18n/react-context": minor
+"@hi18n/react": minor
+---
+
+fix(react)!: change how locales are propagated

--- a/packages/react-context/index.d.ts
+++ b/packages/react-context/index.d.ts
@@ -3,6 +3,6 @@ import React from "react";
 /**
  * A {@link https://reactjs.org/docs/context.html React context} to pass down the current locale.
  *
- * It contains a list of {@link https://en.wikipedia.org/wiki/IETF_language_tag BCP 47 langauge tags}, concatenated by LF "\n".
+ * It contains a list of {@link https://en.wikipedia.org/wiki/IETF_language_tag BCP 47 langauge tags}.
  */
-export const LocaleContext: React.Context<string>;
+export const LocaleContext: React.Context<readonly string[]>;

--- a/packages/react-context/index.js
+++ b/packages/react-context/index.js
@@ -1,4 +1,4 @@
 const React = require("react");
 
-exports.LocaleContext = /* #__PURE__ */ React.createContext("");
+exports.LocaleContext = /* #__PURE__ */ React.createContext(Object.freeze([]));
 /* #__PURE__ */ exports.LocaleContext.displayName = "LocaleContext";

--- a/packages/react-context/index.module.js
+++ b/packages/react-context/index.module.js
@@ -1,4 +1,6 @@
 import React from "react";
 
-export const LocaleContext = /* #__PURE__ */ React.createContext("");
+export const LocaleContext = /* #__PURE__ */ React.createContext(
+  Object.freeze([]),
+);
 /* #__PURE__ */ LocaleContext.displayName = "LocaleContext";

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -39,8 +39,12 @@ export const LocaleProvider: React.FC<{
   const concatenatedLocales = Array.isArray(locales)
     ? locales.join("\n")
     : locales;
+  const memoizedLocales = React.useMemo(
+    () => (concatenatedLocales === "" ? [] : concatenatedLocales.split("\n")),
+    [concatenatedLocales],
+  );
   return (
-    <LocaleContext.Provider value={concatenatedLocales}>
+    <LocaleContext.Provider value={memoizedLocales}>
       {children}
     </LocaleContext.Provider>
   );
@@ -71,8 +75,10 @@ export const LocaleProvider: React.FC<{
 export function useLocales(): string[] {
   // Extending string -> string | readonly string[]
   // to future-proof changes in how context is propagated.
-  const localesConcat: string | readonly string[] =
-    React.useContext(LocaleContext);
+  // Also, removing "readonly" here to correctly type Array.isArray assertion.
+  const localesConcat: string | string[] = React.useContext(LocaleContext) as
+    | string
+    | string[];
   const locales = React.useMemo(
     () =>
       Array.isArray(localesConcat)


### PR DESCRIPTION
## Why

In preparation for v0.2.0.

Simply propagating a frozen array of strings as locales seems useful. It can also be used as a cache key when combined with  WeakMap.

## What

Switch the context type from `string` to `readonly string[]`.

The versions are going to be bumped, but v0.1.0 also has a future-proof in https://github.com/wantedly/hi18n/pull/193.