### PR TITLE
chore(react)!: promote @hi18n/core as a peer dependency

### DIFF
--- a/.changeset/vast-comics-know.md
+++ b/.changeset/vast-comics-know.md
@@ -1,0 +1,5 @@
+---
+"@hi18n/react": minor
+---
+
+chore(react)!: promote @hi18n/core as a peer dependency

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -52,14 +52,15 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "@hi18n/core": "^0.1.16",
     "@types/react": "^16.8.3 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "peerDependencies": {
+    "@hi18n/core": "^0.1.16",
     "@hi18n/react-context": "^0.1.3",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
+    "@hi18n/core": "^0.1.16",
     "@hi18n/react-context": "^0.1.3",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -770,6 +770,7 @@ __metadata:
     typescript: "npm:^5.9.2"
     vitest: "npm:^3.2.4"
   peerDependencies:
+    "@hi18n/core": ^0.1.16
     "@hi18n/react-context": ^0.1.3
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
   languageName: unknown


### PR DESCRIPTION
## Why

As `@hi18n/core`'s internal message structure changes between versions, it is essential that we use the same version of `@hi18n/core` across both translation definitions and translation uses.

## What

Promote `@hi18n/core` as `@hi18n/react`'s peer dependency from a dependency.