### PR TITLE
feat(core): add new message builder

### DIFF
--- a/.changeset/flat-snails-relate.md
+++ b/.changeset/flat-snails-relate.md
@@ -1,0 +1,5 @@
+---
+"@hi18n/core": patch
+---
+
+feat(core): add new message builder

--- a/README.md
+++ b/README.md
@@ -17,13 +17,14 @@ yarn add -D @hi18n/cli
 Put the following file named like `src/locale/index.ts`:
 
 ```typescript
-import { Book, Catalog, Message, msg } from "@hi18n/core";
+import { Book, Catalog, Message } from "@hi18n/core";
+import { msg, arg } from "@hi18n/core/msg";
 
 type Vocabulary = {
   "example/greeting": Message<{ name: string }>;
 };
 const catalogEn = new Catalog<Vocabulary>("en", {
-  "example/greeting": msg("Hello, {name}!"),
+  "example/greeting": msg`Hello, ${arg("name")}!"`,
 });
 export const book = new Book<Vocabulary>({ en: catalogEn });
 ```
@@ -213,13 +214,18 @@ const { t } = useI18n(book);
 
 ## Message syntax
 
-Message roughly resembles [ICU MessageFormat](https://unicode-org.github.io/icu/userguide/format_parse/messages/).
+We have two syntaxes for messages.
 
-- Simple message: `Hello, world!`
-- Interpolation: `Hello, {name}!`
-- Interleaving with markups: `Please <link>read the license agreement</link> before continuing.`
+- The JavaScript DSL can be used to build type-safe messages.
+  - Simple message: ``msg`Hello, world!` ``
+  - Interpolation: ``msg`Hello, ${arg("name")}!` ``
+  - Interleaving with markups: ``msg`Please ${tag("link")(msg`read the license agreement`)} before continuing.`
+- In the MessageFormat syntax, a message roughly resembles [ICU MessageFormat](https://unicode-org.github.io/icu/userguide/format_parse/messages/).
+  - Simple message: `Hello, world!`
+  - Interpolation: `Hello, {name}!`
+  - Interleaving with markups: `Please <link>read the license agreement</link> before continuing.`
 
-See [msgfmt.md](docs/msgfmt.md) for more details.
+See [formatting.md](docs/formatting.md) for more details.
 
 ## Loading only a specific language
 

--- a/docs/formatting.md
+++ b/docs/formatting.md
@@ -1,0 +1,57 @@
+# Message syntax
+
+There are roughly two ways to describe messages:
+
+- **JavaScript DSL** uses JavaScript functions to build type-safe messages.
+- **MessageFormat syntax** uses a dedicated syntax for translation structures.
+
+## JavaScript DSL
+
+To write translations in JavaScript DSL, use various helpers from `@hi18n/core/msg`.
+
+```ts
+import { Catalog, type Message } from "@hi18n/core";
+import { msg, arg } from "@hi18n/core/msg";
+
+type Vocabulary = {
+  "root/greeting": Message<{ name: string }>;
+};
+
+const catalogEn = new Catalog<Vocabulary>("en", {
+  "root/greeting": msg`Hello, ${arg("name")}!`,
+});
+```
+
+## MessageFormat syntax
+
+To write translations in MessageFormat syntax, use the `mf1` helper from `@hi18n/core/msg`.
+
+```ts
+import { Catalog, type Message } from "@hi18n/core";
+import { mf1 } from "@hi18n/core/msg";
+
+type Vocabulary = {
+  "root/greeting": Message<{ name: string }>;
+};
+
+const catalogEn = new Catalog<Vocabulary>("en", {
+  "root/greeting": mf1("Hello, {name}!"),
+});
+```
+
+There is also a `msg` helper from `@hi18n/core` for backward compatibility, but `@hi18n/core/msg` is preferred.
+
+```ts
+// msg is deprecated. Use mf1.
+import { Catalog, type Message, msg } from "@hi18n/core";
+
+type Vocabulary = {
+  "root/greeting": Message<{ name: string }>;
+};
+
+const catalogEn = new Catalog<Vocabulary>("en", {
+  "root/greeting": msg("Hello, {name}!"),
+});
+```
+
+For syntax structures used within the function, see [Message syntax (MessageFormat 1.0)](./msgfmt.md).

--- a/docs/message-dsl.md
+++ b/docs/message-dsl.md
@@ -1,0 +1,204 @@
+# Message syntax (JavaScript DSL)
+
+In the JavaScript DSL, messages are constructed in a type-safe manner using JavaScript fuctions.
+
+## Plain texts
+
+plain texts are constructed using the `msg` template tag exported from `@hi18n/core/msg`.
+
+```ts
+msg`Hello, world!`;
+```
+
+The function of the same name exported from `@hi18n/core` can also function in the same way, but the one from `@hi18n/core/msg` is recommended.
+
+You can use escapes defined in JavaScript, and no escapes other than them are recognized. Specifically, symbols like `'`, `{`, `}`, `<` and `>` are recognized as it is unlike in MessageFormat.
+
+```ts
+msg`'' is a pair of single quotes`;
+msg`</sarcasm> appears as it is`;
+msg`The text (\n) contains Line Feed`;
+```
+
+## Interpolation
+
+You can embed complex constructions in the tagged template.
+
+The example below demonstrates how to embed the string-valued parameter named `name`
+in the message.
+
+```ts
+msg`Hello, ${arg("name")}!`;
+```
+
+## String-valued parameters
+
+Use `arg()` helper from `@hi18n/core/msg` without the second parameter to embed a string-valued parameter.
+
+```ts
+msg`Hello, ${arg("name")}!`;
+```
+
+## Number-valued parameters
+
+Give `"number"` as `arg()`'s second parameter to embed a number-valued parameter.
+
+```ts
+msg`Score: ${arg("score", "number")}`;
+// => Score: 1,234,567
+```
+
+Simple style options:
+
+```ts
+// default (equivalent to {})
+arg("score", "number", "number");
+// equivalent to { maximumFractionDigits: 0 }
+arg("score", "number", "integer");
+// equivalent to { style: "percent" }
+arg("score", "number", "percent");
+```
+
+Complex style options:
+
+```ts
+arg("score", "number", {
+  style: "decimal",
+  minimumIntegerDigits: 5,
+  minimumFractionDigits: 5,
+  maximumFractionDigits: 8,
+  signDisplay: "always",
+});
+```
+
+Most [options to `Intl.NumberFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#options) can be specified.
+
+## Date-valued, time-valued, and datetime-valued parameters
+
+Give `"date"` as `arg()`'s second parameter to embed a date-valued parameter.
+Similarly, you can use `"time"` and `"datetime"`.
+
+```ts
+arg("due", "date");
+// => 1/20/2025
+
+arg("due", "time");
+// => 12:34:56 AM
+
+arg("due", "datetime");
+// => 1/20/2025, 12:34:56 AM
+```
+
+When styles are omitted just like the above, the default styles are assumed:
+
+- for `"date"`, as `{ year: "numeric", month: "numeric", date: "numeric" }`
+- for `"time"`, as `{ hour: "numeric", minute: "numeric", second: "numeric" }`
+- for `"datetime"`, the combination of both
+
+date/time shorthands:
+
+```ts
+// Equivalent of { dateStyle: "short" }
+arg("due", "date", "short");
+// Equivalent of { dateStyle: "medium" }
+arg("due", "date", "medium");
+// Equivalent of { dateStyle: "long" }
+arg("due", "date", "long");
+// Equivalent of { dateStyle: "full" }
+arg("due", "date", "full");
+// Equivalent of { timeStyle: "short" }
+arg("due", "time", "short");
+// Equivalent of { timeStyle: "medium" }
+arg("due", "time", "medium");
+// Equivalent of { timeStyle: "long" }
+arg("due", "time", "long");
+// Equivalent of { timeStyle: "full" }
+arg("due", "time", "full");
+
+// Equivalent of { dateStyle: "short", timeStyle: "short" }
+arg("due", "datetime", "short");
+// Equivalent of { dateStyle: "medium", timeStyle: "medium" }
+arg("due", "datetime", "medium");
+// Equivalent of { dateStyle: "long", timeStyle: "long" }
+arg("due", "datetime", "long");
+// Equivalent of { dateStyle: "full", timeStyle: "full" }
+arg("due", "datetime", "full");
+```
+
+Full options example:
+
+```ts
+arg("due", "datetime", {
+  month: "long",
+  day: "numeric",
+  hour: "numeric",
+  minute: "2-digit",
+});
+```
+
+Most [options to `Intl.DateTimeFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#options) can be specified.
+
+## Plurals
+
+English has two plural forms. Arabic has six! In this case, use `plural` to branch over the number of items you have.
+
+```ts
+plural("count").branch(
+  when("one", msg`You have ${arg("count", "number")} message.`),
+  otherwise(msg`You have ${arg("count", "number")} messages.`),
+);
+```
+
+Here, the condition is one of:
+
+- Plural category other than `"other"`. That is, `"zero"`, `"one"`, `"two"`, `"few"`, or `"many"`.
+  Note that the names may be inaccurate.
+  For example, "one" may include 21 in some languages.
+  "two" does not match nothing in English.
+- A number for exact match.
+
+### subtraction
+
+For backward compatibility, hi18n does a simple subtraction for you.
+
+Specify the `subtract` option in `plural()` or `arg(..., "number")`.
+
+```ts
+plural("count", { subtract: 1 }).branch(
+  when(0, msg`No one is online.`),
+  when(1, msg`${arg("friendName")} is online.`),
+  when(
+    "one",
+    msg`${arg("friendName")} and ${arg("count", "number")} other are online.`,
+  ),
+  otherwise(
+    msg`${arg("friendName")} and ${arg("count", "number")} others are online.`,
+  ),
+);
+```
+
+Note that `subtract` is not applied to exact matching.
+Therefore, in the example above, each branch matches in the following conditions:
+
+- The branch `0` matches when `count` is 0.
+- The branch `1` matches when `count` is 1.
+- The branch `one` matches when `count` is 2.
+- The `otherwise` branch matches otherwise.
+
+### cardinals and ordinals
+
+`plurals()` currently works only for cardinal numbers.
+
+## Markups
+
+You can include markups in messages when using `@hi18n/react`.
+
+Markup is done by wrapping a part of the message using `tag(tagName)(...)`.
+The tagName behaves like a parameter and should be filled by the caller.
+
+There is no such thing as attributes in the message itself.
+The caller should fill the element attributes if necessary.
+
+```ts
+msg`Hello, ${tag("emphasis")(arg("name"))}`;
+```

--- a/docs/msgfmt.md
+++ b/docs/msgfmt.md
@@ -1,4 +1,4 @@
-# Message syntax
+# Message syntax (MessageFormat 1.0)
 
 Message roughly resembles [ICU MessageFormat](https://unicode-org.github.io/icu/userguide/format_parse/messages/).
 

--- a/packages/core/msg.d.ts
+++ b/packages/core/msg.d.ts
@@ -1,0 +1,3 @@
+// Type definition for consumers with moduleResolution older than node16.
+
+export * from "./cjs/dist/msg";

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,13 +30,20 @@
     "dist/**/*",
     "cjs/**/*",
     "src/**/*",
-    "!src/**/*.test.ts"
+    "!src/**/*.test.ts",
+    "msg.d.ts"
   ],
   "type": "module",
   "main": "./cjs/dist/index.js",
   "exports": {
-    "require": "./cjs/dist/index.js",
-    "default": "./dist/index.js"
+    ".": {
+      "require": "./cjs/dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./msg": {
+      "require": "./cjs/dist/msg.js",
+      "default": "./dist/msg.js"
+    }
   },
   "sideEffects": false,
   "scripts": {

--- a/packages/core/src/index-new.test.ts
+++ b/packages/core/src/index-new.test.ts
@@ -1,0 +1,602 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+
+import { describe, expect, it, vitest } from "vitest";
+import {
+  Book,
+  Catalog,
+  type Message,
+  getTranslator,
+  translationId,
+  type TranslationId,
+  MissingLocaleError,
+  NoLocaleError,
+  type ErrorHandler,
+  MessageError,
+  MessageEvaluationError,
+  MissingTranslationError,
+  preloadCatalogs,
+} from "./index.ts";
+import { arg, msg, otherwise, plural, todo, when } from "./msg.ts";
+
+const nodeVersion = (globalThis as unknown as { process: { version: string } })
+  .process.version;
+
+type Vocabulary = {
+  "example/greeting": Message;
+  "example/greeting2": Message<{ name: string }>;
+  "example/apples": Message<{ count: number }>;
+  "example/additional": Message;
+  "example/date": Message<{ today: Date }>;
+  "example/date2": Message<{ today: Date }>;
+};
+
+const catalogJa = new Catalog<Vocabulary>("ja", {
+  "example/greeting": msg`こんにちは!`,
+  "example/greeting2": msg`こんにちは、${arg("name")}さん!`,
+  "example/apples": msg`リンゴは${arg("count", "number")}個あります。`,
+  "example/additional": msg`日本限定企画!`,
+  "example/date": msg`今日は${arg("today", "date", "medium")}です。`,
+  "example/date2": msg`今日は${arg("today", "datetime", {
+    month: "long",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  })}です。`,
+});
+const catalogEn = new Catalog<Vocabulary>("en", {
+  "example/greeting": msg`Hello!`,
+  "example/greeting2": msg`Hello, ${arg("name")}!`,
+  "example/apples": plural("count").branch(
+    when("one", msg`There is ${arg("count", "number")} apple.`),
+    otherwise(msg`There are ${arg("count", "number")} apples.`),
+  ),
+  // An example of not-yet-translated texts
+  "example/additional": todo(msg`日本限定企画!`),
+  "example/date": msg`Today is ${arg("today", "date", "medium")}.`,
+  "example/date2": msg`Today is ${arg("today", "datetime", {
+    month: "long",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  })}.`,
+});
+const book = new Book<Vocabulary>({
+  ja: catalogJa,
+  en: catalogEn,
+});
+
+describe("Book", () => {
+  it("generates translation", () => {
+    {
+      const { t } = getTranslator(book, "ja");
+      expect(t("example/greeting")).toBe("こんにちは!");
+    }
+    {
+      const { t } = getTranslator(book, "en");
+      expect(t("example/greeting")).toBe("Hello!");
+    }
+  });
+
+  it("raises an error for missing translation language", () => {
+    expect(() => {
+      getTranslator(book, "zh");
+    }).toThrow("Missing locale: zh");
+  });
+
+  it("raises an error for empty locale list", () => {
+    expect(() => {
+      getTranslator(book, []);
+    }).toThrow("No locale specified");
+  });
+
+  it("uses the first specified locale", () => {
+    {
+      const { t } = getTranslator(book, ["ja", "en"]);
+      expect(t("example/greeting")).toBe("こんにちは!");
+    }
+    {
+      const { t } = getTranslator(book, ["en", "ja"]);
+      expect(t("example/greeting")).toBe("Hello!");
+    }
+  });
+
+  it("raises an error for missing translation id", () => {
+    const { t } = getTranslator(book, "en");
+    expect(() => {
+      // @ts-expect-error
+      t("example/non-existent-translation-id");
+    }).toThrow(
+      "Error translating example/non-existent-translation-id in en: Missing translation",
+    );
+  });
+
+  it("does a simple interpolation", () => {
+    {
+      const { t } = getTranslator(book, "ja");
+      expect(t("example/greeting2", { name: "太郎" })).toBe(
+        "こんにちは、太郎さん!",
+      );
+    }
+    {
+      const { t } = getTranslator(book, "en");
+      expect(t("example/greeting2", { name: "Taro" })).toBe("Hello, Taro!");
+    }
+  });
+
+  it("does plural interpolation", () => {
+    {
+      const { t } = getTranslator(book, "ja");
+      expect(t("example/apples", { count: 1 })).toBe("リンゴは1個あります。");
+      expect(t("example/apples", { count: 12345 })).toBe(
+        "リンゴは12,345個あります。",
+      );
+    }
+    {
+      const { t } = getTranslator(book, "en");
+      expect(t("example/apples", { count: 1 })).toBe("There is 1 apple.");
+      expect(t("example/apples", { count: 12345 })).toBe(
+        "There are 12,345 apples.",
+      );
+    }
+  });
+
+  it("raises an error for missing arguments", () => {
+    const { t } = getTranslator(book, "en");
+    expect(() => {
+      // @ts-expect-error
+      t("example/greeting2");
+    }).toThrow(
+      "Error translating example/greeting2 in en: Missing argument: name",
+    );
+    expect(() => {
+      // @ts-expect-error
+      t("example/greeting2", {});
+    }).toThrow(
+      "Error translating example/greeting2 in en: Missing argument: name",
+    );
+  });
+
+  it("raises an error for invalid argument types", () => {
+    const { t } = getTranslator(book, "en");
+    expect(() => {
+      // @ts-expect-error
+      t("example/greeting2", { name: 42 });
+    }).toThrow(
+      "Error translating example/greeting2 in en: Invalid argument name: expected string, got 42",
+    );
+  });
+
+  it("evaluates datetime", () => {
+    const date = new Date(Date.UTC(2006, 0, 2, 22, 4, 5, 999));
+    {
+      const { t } = getTranslator(book, "en");
+      expect(t("example/date", { today: date, timeZone: "MST" })).toBe(
+        "Today is Jan 2, 2006.",
+      );
+      expect(t("example/date2", { today: date, timeZone: "MST" })).toMatch(
+        /^(Today is January 2, 3:04 PM\.|Today is January 2 at 3:04 PM\.)$/,
+      );
+    }
+    {
+      const { t } = getTranslator(book, "ja");
+      expect(t("example/date", { today: date, timeZone: "MST" })).toBe(
+        "今日は2006/01/02です。",
+      );
+      expect(t("example/date2", { today: date, timeZone: "MST" })).toBe(
+        "今日は1月2日 15:04です。",
+      );
+    }
+    {
+      const { t } = getTranslator(book, "ja");
+      expect(t("example/date", { today: date, timeZone: "JST" })).toBe(
+        "今日は2006/01/03です。",
+      );
+      expect(t("example/date2", { today: date, timeZone: "JST" })).toBe(
+        "今日は1月3日 7:04です。",
+      );
+    }
+  });
+
+  it("raises an error for missing timeZone parameter", () => {
+    const { t } = getTranslator(book, "en");
+    const date = new Date(Date.UTC(2006, 0, 2, 22, 4, 5, 999));
+    expect(t("example/date", { today: date, timeZone: "MST" })).toBe(
+      "Today is Jan 2, 2006.",
+    );
+    expect(() => {
+      // @ts-expect-error
+      t("example/date", { today: date });
+    }).toThrow(
+      "Error translating example/date in en: Missing argument: timeZone",
+    );
+  });
+
+  describe("dynamic translation", () => {
+    it("generates translation", () => {
+      const id = translationId(book, "example/greeting");
+      {
+        const { t } = getTranslator(book, "ja");
+        expect(t.dynamic(id)).toBe("こんにちは!");
+      }
+      {
+        const { t } = getTranslator(book, "en");
+        expect(t.dynamic(id)).toBe("Hello!");
+      }
+    });
+
+    it("raises an error for missing translation id", () => {
+      const id: TranslationId<Vocabulary> = translationId(
+        book,
+        // @ts-expect-error
+        "example/non-existent-translation-id",
+      );
+      const { t } = getTranslator(book, "en");
+      expect(() => {
+        t.dynamic(id);
+      }).toThrow(
+        "Error translating example/non-existent-translation-id in en: Missing translation",
+      );
+    });
+
+    it("does a simple interpolation", () => {
+      const id = translationId(book, "example/greeting2");
+      {
+        const { t } = getTranslator(book, "ja");
+        expect(t.dynamic(id, { name: "太郎" })).toBe("こんにちは、太郎さん!");
+      }
+      {
+        const { t } = getTranslator(book, "en");
+        expect(t.dynamic(id, { name: "Taro" })).toBe("Hello, Taro!");
+      }
+    });
+
+    it("does plural interpolation", () => {
+      const id = translationId(book, "example/apples");
+      {
+        const { t } = getTranslator(book, "ja");
+        expect(t.dynamic(id, { count: 1 })).toBe("リンゴは1個あります。");
+        expect(t.dynamic(id, { count: 12345 })).toBe(
+          "リンゴは12,345個あります。",
+        );
+      }
+      {
+        const { t } = getTranslator(book, "en");
+        expect(t.dynamic(id, { count: 1 })).toBe("There is 1 apple.");
+        expect(t.dynamic(id, { count: 12345 })).toBe(
+          "There are 12,345 apples.",
+        );
+      }
+    });
+
+    it("raises an error for missing arguments", () => {
+      const id = translationId(book, "example/greeting2");
+      const { t } = getTranslator(book, "en");
+      expect(() => {
+        // @ts-expect-error
+        t.dynamic(id);
+      }).toThrow(
+        "Error translating example/greeting2 in en: Missing argument: name",
+      );
+      expect(() => {
+        // @ts-expect-error
+        t.dynamic(id, {});
+      }).toThrow(
+        "Error translating example/greeting2 in en: Missing argument: name",
+      );
+    });
+
+    it("raises an error for invalid argument types", () => {
+      const id = translationId(book, "example/greeting2");
+      const { t } = getTranslator(book, "en");
+      expect(() => {
+        // @ts-expect-error
+        t.dynamic(id, { name: 42 });
+      }).toThrow(
+        "Error translating example/greeting2 in en: Invalid argument name: expected string, got 42",
+      );
+    });
+  });
+
+  describe("translation bootstrapping", () => {
+    it("Returns placeholder", () => {
+      const { t } = getTranslator(book, "ja");
+      expect(t.todo("example/greeting")).toBe("[TODO: example/greeting]");
+      expect(t.todo("example/greeting2")).toBe("[TODO: example/greeting2]");
+      expect(t.todo("example/foobar")).toBe("[TODO: example/foobar]");
+    });
+
+    it("Discards parameters", () => {
+      const { t } = getTranslator(book, "ja");
+      expect(t.todo("example/greeting", { name: "John" })).toBe(
+        "[TODO: example/greeting]",
+      );
+      expect(t.todo("example/greeting2", { name: "John" })).toBe(
+        "[TODO: example/greeting2]",
+      );
+      expect(t.todo("example/foobar", { name: "John" })).toBe(
+        "[TODO: example/foobar]",
+      );
+    });
+  });
+
+  describe("handleError", () => {
+    it("without implicitLocale, doesn't handle errors when locale is missing", () => {
+      const handleError = vitest.fn<ErrorHandler>();
+      const book = new Book<Vocabulary>(
+        {
+          ja: catalogJa,
+          en: catalogEn,
+        },
+        { handleError },
+      );
+      expect(() => getTranslator(book, [])).toThrow(NoLocaleError);
+      expect(handleError).not.toHaveBeenCalled();
+    });
+
+    it("with implicitLocale, handles errors when locale is missing", () => {
+      const handleError = vitest.fn<ErrorHandler>();
+      const book = new Book<Vocabulary>(
+        {
+          ja: catalogJa,
+          en: catalogEn,
+        },
+        { handleError, implicitLocale: "en" },
+      );
+      expect(() => getTranslator(book, [])).not.toThrow();
+      expect(handleError).toHaveBeenCalledWith(new NoLocaleError(), "error");
+
+      const { t } = getTranslator(book, []);
+      expect(t("example/greeting")).toBe("Hello!");
+    });
+
+    it("without implicitLocale, doesn't handle errors when locale is invalid", () => {
+      const handleError = vitest.fn<ErrorHandler>();
+      const book = new Book<Vocabulary>(
+        {
+          ja: catalogJa,
+          en: catalogEn,
+        },
+        { handleError },
+      );
+      expect(() => getTranslator(book, "foo")).toThrow(
+        new MissingLocaleError({
+          locale: "foo",
+          availableLocales: ["ja", "en"],
+        }),
+      );
+      expect(handleError).not.toHaveBeenCalled();
+    });
+
+    it("with implicitLocale, handles errors when locale is invalid", () => {
+      const handleError = vitest.fn<ErrorHandler>();
+      const book = new Book<Vocabulary>(
+        {
+          ja: catalogJa,
+          en: catalogEn,
+        },
+        { handleError, implicitLocale: "en" },
+      );
+      expect(() => getTranslator(book, ["foo"])).not.toThrow();
+      expect(handleError).toHaveBeenCalledWith(
+        new MissingLocaleError({
+          locale: "foo",
+          availableLocales: ["ja", "en"],
+        }),
+        "error",
+      );
+
+      const { t } = getTranslator(book, ["foo"]);
+      expect(t("example/greeting")).toBe("Hello!");
+    });
+
+    it("handles errors when translation is missing", () => {
+      if (/v(18|20)/.test(nodeVersion)) {
+        return;
+      }
+      const handleError = vitest.fn<ErrorHandler>();
+      const book = new Book<Vocabulary>(
+        {
+          ja: catalogJa,
+          en: catalogEn,
+        },
+        { handleError },
+      );
+
+      const { t } = getTranslator(book, "en");
+      // @ts-expect-error it is deliberate
+      expect(t("example/nonexistent")).toBe("[example/nonexistent]");
+
+      expect(handleError).toHaveBeenCalled();
+      expect(handleError.mock.lastCall?.[0]).toEqual(
+        new MessageError({
+          cause: new MissingTranslationError(),
+          id: "example/nonexistent",
+          locale: "en",
+        }),
+      );
+      expect(handleError.mock.lastCall?.[1]).toEqual("error");
+      // expect(handleError).toHaveBeenCalledWith(
+      //   new MessageError({
+      //     cause: new MissingTranslationError(),
+      //     id: "example/nonexistent",
+      //     locale: "en",
+      //   }),
+      //   "error"
+      // );
+    });
+
+    it("handles errors when it failed to evaluate translations", () => {
+      if (/v(18|20)/.test(nodeVersion)) {
+        return;
+      }
+      const handleError = vitest.fn<ErrorHandler>();
+      const book = new Book<Vocabulary>(
+        {
+          ja: catalogJa,
+          en: catalogEn,
+        },
+        { handleError },
+      );
+
+      const { t } = getTranslator(book, "en");
+      // @ts-expect-error it is deliberate
+      expect(t("example/greeting2", { name: null })).toBe(
+        "[example/greeting2]",
+      );
+
+      expect(handleError).toHaveBeenCalled();
+      expect(handleError.mock.lastCall?.[0]).toEqual(
+        new MessageError({
+          // cause: new ArgumentTypeError({
+          //   argName: "name",
+          //   expectedType: "string",
+          //   got: null,
+          // }),
+          cause: new MessageEvaluationError(
+            "Invalid argument name: expected string, got null",
+          ),
+          id: "example/greeting2",
+          locale: "en",
+        }),
+      );
+      expect(handleError.mock.lastCall?.[1]).toEqual("error");
+      // expect(handleError).toHaveBeenCalledWith(
+      //   new MessageError({
+      //     cause: new ArgumentTypeError({
+      //       argName: "name",
+      //       expectedType: "string",
+      //       got: null,
+      //     }),
+      //     id: "example/greeting2",
+      //     locale: "en",
+      //   }),
+      //   "error"
+      // );
+    });
+  });
+
+  describe("lazy loading", () => {
+    it("allows lazy-loading", async () => {
+      const book = new Book<Vocabulary>({
+        ja: () => Promise.resolve({ default: catalogJa }),
+        en: () => Promise.resolve({ default: catalogEn }),
+      });
+      await book.loadCatalog("ja");
+
+      const { t } = getTranslator(book, "ja");
+      expect(t("example/greeting")).toBe("こんにちは!");
+    });
+
+    it("allows mixed eager/lazy-loading", async () => {
+      const book = new Book<Vocabulary>({
+        ja: () => Promise.resolve({ default: catalogJa }),
+        en: catalogEn,
+      });
+      await book.loadCatalog("ja");
+
+      const { t } = getTranslator(book, "ja");
+      expect(t("example/greeting")).toBe("こんにちは!");
+    });
+
+    it("loadCatalog does nothing if the catalog has already been loaded", async () => {
+      const book = new Book<Vocabulary>({
+        ja: () => Promise.resolve({ default: catalogJa }),
+        en: () => Promise.resolve({ default: catalogEn }),
+      });
+      await book.loadCatalog("ja");
+      // again
+      await book.loadCatalog("ja");
+
+      const { t } = getTranslator(book, "ja");
+      expect(t("example/greeting")).toBe("こんにちは!");
+    });
+
+    it("loadCatalog does nothing if the catalog is not a lazy-loaded one", async () => {
+      const book = new Book<Vocabulary>({
+        ja: catalogJa,
+        en: () => Promise.resolve({ default: catalogEn }),
+      });
+      await book.loadCatalog("ja");
+
+      const { t } = getTranslator(book, "ja");
+      expect(t("example/greeting")).toBe("こんにちは!");
+    });
+
+    it("getTranslator errors if the locale is yet to be loaded", async () => {
+      const book = new Book<Vocabulary>({
+        ja: () => Promise.resolve({ default: catalogJa }),
+        en: () => Promise.resolve({ default: catalogEn }),
+      });
+      await book.loadCatalog("ja");
+
+      expect(() => getTranslator(book, "en")).toThrow("Catalog not loaded: en");
+    });
+
+    it("getTranslator throw a Promise if requested", async () => {
+      const book = new Book<Vocabulary>({
+        ja: () => Promise.resolve({ default: catalogJa }),
+        en: () => Promise.resolve({ default: catalogEn }),
+      });
+      await book.loadCatalog("ja");
+
+      expect(() => getTranslator(book, "en", { throwPromise: true })).toThrow(
+        Promise,
+      );
+    });
+
+    it("getTranslator throw a Promise that resolves to the loaded state", async () => {
+      const book = new Book<Vocabulary>({
+        ja: () => Promise.resolve({ default: catalogJa }),
+        en: () => Promise.resolve({ default: catalogEn }),
+      });
+      await book.loadCatalog("ja");
+
+      try {
+        getTranslator(book, "en", { throwPromise: true });
+      } catch (e) {
+        if (typeof (e as Promise<void>).then === "function") {
+          await (e as Promise<void>);
+        } else {
+          throw e;
+        }
+      }
+      const { t } = getTranslator(book, "ja");
+      expect(t("example/greeting")).toBe("こんにちは!");
+    });
+
+    it("loadCatalog errors on locale mismatch", async () => {
+      const book = new Book<Vocabulary>({
+        // locale mismatch
+        ja: () => Promise.resolve({ default: catalogEn }),
+        en: () => Promise.resolve({ default: catalogEn }),
+      });
+      await expect(book.loadCatalog("ja")).rejects.toThrow(
+        "Locale mismatch: expected ja, got en",
+      );
+    });
+
+    it("preloadCatalogs loads an appropriate catalog", async () => {
+      const book = new Book<Vocabulary>({
+        ja: () => Promise.resolve({ default: catalogJa }),
+        en: () => Promise.resolve({ default: catalogEn }),
+      });
+      await preloadCatalogs(book, ["zh", "ja"]); // -> ja is selected
+
+      const { t } = getTranslator(book, ["zh", "ja"]);
+      expect(t("example/greeting")).toBe("こんにちは!");
+    });
+  });
+});
+
+function expectType<T>(_x: T) {
+  /* Nothing to do */
+}
+expectType<Message>(msg`foo`);
+
+// Translation with unintended arguments
+{
+  // @ts-expect-error
+  expectType<Message>(msg`${arg("name")}`);
+  // @ts-expect-error
+  expectType<Message<{ value: string }>>(msg`${arg("name")}`);
+}

--- a/packages/core/src/msg.ts
+++ b/packages/core/src/msg.ts
@@ -1,0 +1,28 @@
+/**
+ * @packageDocumentation
+ * @module @hi18n/core/msg
+ *
+ * This module provides functions and types for creating type-safe messages
+ * for each language.
+ *
+ * @example
+ *   ```ts
+ *   import { Catalog, type Message } from "@hi18n/core";
+ *   import { arg, msg, plural } from "@hi18n/core/msg";
+ *
+ *   export type Vocabulary = {
+ *     "root/greeting": Message<{ name: string }>;
+ *   };
+ *
+ *   const catalogEn = new Catalog<Vocabulary>("en", {
+ *     "root/greeting": msg`Hello, ${arg("name")}!`,
+ *   });
+ *   ```
+ */
+
+export * from "./msg/arg.ts";
+export * from "./msg/tagged-template.ts";
+export * from "./msg/branch.ts";
+export * from "./msg/mf1.ts";
+export * from "./msg/plural.ts";
+export * from "./msg/todo.ts";

--- a/packages/core/src/msg/arg.ts
+++ b/packages/core/src/msg/arg.ts
@@ -1,0 +1,201 @@
+import type { Message } from "../opaque.ts";
+import { dateArg, type DateArgStyle } from "./arg/date.ts";
+import { dateTimeArg, type DateTimeArgStyle } from "./arg/datetime.ts";
+import { numberArg, type NumberArgStyle } from "./arg/number.ts";
+import { stringArg } from "./arg/string.ts";
+import { timeArg, type TimeArgStyle } from "./arg/time.ts";
+
+export type {
+  NumberArgStyle,
+  SimpleNumberArgStyle,
+  ComplexNumberArgStyle,
+  RoundingPriority,
+  RoundingIncrement,
+  RoundingMode,
+  TrailingZeroDisplay,
+  NumberNotation,
+  NumberCompactDisplay,
+  UseGrouping,
+  SignDisplay,
+} from "./arg/number.ts";
+export type { DateArgStyle, ComplexDateArgStyle } from "./arg/date.ts";
+export type { TimeArgStyle, ComplexTimeArgStyle } from "./arg/time.ts";
+export type {
+  DateTimeArgStyle,
+  DateTimeArgShorthandPair,
+  DateArgStyleShorthand,
+  TimeArgStyleShorthand,
+  DateTimeArgStyleShorthand,
+  ComplexDateTimeArgStyle,
+  WeekdayStyle,
+  EraStyle,
+  YearStyle,
+  MonthStyle,
+  DayStyle,
+  DayPeriodStyle,
+  HourStyle,
+  MinuteStyle,
+  SecondStyle,
+  FractionalSecondDigits,
+  TimeZoneNameStyle,
+} from "./arg/datetime.ts";
+
+/**
+ * Creates a type-safe message for string interpolation.
+ *
+ * @param name The name of the string-valued parameter.
+ * @param type The type of the parameter.
+ *   Valid values:
+ *   - **string (default)**
+ *   - number
+ *   - date
+ *   - time
+ *   - datetime
+ * @returns A (part of) message that can be stored in a Catalog.
+ *
+ * @since 0.2.1 (`@hi18n/core`)
+ *
+ * @example
+ *   ```ts
+ *   const catalogEn = new Catalog<Vocabulary>("en", {
+ *    greeting: msg`Hello, ${arg("name")}!`,
+ *   });
+ *   ```
+ */
+export function arg<const Name extends string | number>(
+  name: Name,
+  type?: "string",
+): Message<{ [K in Name]: string }>;
+
+/**
+ * Creates a type-safe message for number interpolation.
+ *
+ * @param name The name of the number-valued parameter.
+ * @param type The type of the parameter.
+ *   Valid values:
+ *   - string (default)
+ *   - **number**
+ *   - date
+ *   - time
+ *   - datetime
+ * @returns A (part of) message that can be stored in a Catalog.
+ *
+ * @since 0.2.1 (`@hi18n/core`)
+ *
+ * @example
+ *   ```ts
+ *   const catalogEn = new Catalog<Vocabulary>("en", {
+ *    greeting: msg`You have ${arg("unreadCount", "number", "integer")} unread messages.`,
+ *   });
+ *   ```
+ */
+export function arg<const Name extends string | number>(
+  name: Name,
+  type: "number",
+  argStyle?: NumberArgStyle,
+): Message<{ [K in Name]: number | bigint }>;
+
+/**
+ * Creates a type-safe message for date interpolation.
+ *
+ * @param name The name of the date-valued parameter.
+ * @param type The type of the parameter.
+ *   Valid values:
+ *   - string (default)
+ *   - number
+ *   - **date**
+ *   - time
+ *   - datetime
+ * @returns A (part of) message that can be stored in a Catalog.
+ *
+ * @since 0.2.1 (`@hi18n/core`)
+ *
+ * @example
+ *   ```ts
+ *   const catalogEn = new Catalog<Vocabulary>("en", {
+ *    greeting: msg`The event is on ${arg("eventDate", "date")}.`,
+ *   });
+ *   ```
+ */
+export function arg<const Name extends string | number>(
+  name: Name,
+  type: "date",
+  argStyle?: DateArgStyle,
+): Message<{ [K in Name]: Date }>;
+
+/**
+ * Creates a type-safe message for time interpolation.
+ *
+ * @param name The name of the time-valued parameter.
+ * @param type The type of the parameter.
+ *   Valid values:
+ *   - string (default)
+ *   - number
+ *   - date
+ *   - **time**
+ *   - datetime
+ * @returns A (part of) message that can be stored in a Catalog.
+ *
+ * @since 0.2.1 (`@hi18n/core`)
+ *
+ * @example
+ *   ```ts
+ *   const catalogEn = new Catalog<Vocabulary>("en", {
+ *    greeting: msg`The meeting is at ${arg("meetingTime", "time")}.`,
+ *   });
+ *   ```
+ */
+export function arg<const Name extends string | number>(
+  name: Name,
+  type: "time",
+  argStyle?: TimeArgStyle,
+): Message<{ [K in Name]: Date }>;
+
+/**
+ * Creates a type-safe message for datetime interpolation.
+ *
+ * @param name The name of the datetime-valued parameter.
+ * @param type The type of the parameter.
+ *   Valid values:
+ *   - string (default)
+ *   - number
+ *   - date
+ *   - time
+ *   - **datetime**
+ * @returns A (part of) message that can be stored in a Catalog.
+ *
+ * @since 0.2.1 (`@hi18n/core`)
+ *
+ * @example
+ *   ```ts
+ *   const catalogEn = new Catalog<Vocabulary>("en", {
+ *    greeting: msg`The appointment is on ${arg("appointmentDateTime", "datetime")}.`,
+ *   });
+ *   ```
+ */
+export function arg<const Name extends string | number>(
+  name: Name,
+  type: "datetime",
+  argStyle?: DateTimeArgStyle,
+): Message<{ [K in Name]: Date }>;
+
+export function arg(
+  name: string | number,
+  type: "string" | "number" | "date" | "time" | "datetime" = "string",
+  argStyle?: NumberArgStyle | DateArgStyle | TimeArgStyle | DateTimeArgStyle,
+): Message<never> {
+  switch (type) {
+    case "string":
+      return stringArg(name);
+    case "number":
+      return numberArg(name, argStyle as NumberArgStyle | undefined);
+    case "date":
+      return dateArg(name, argStyle as DateArgStyle | undefined);
+    case "time":
+      return timeArg(name, argStyle as TimeArgStyle | undefined);
+    case "datetime":
+      return dateTimeArg(name, argStyle as DateTimeArgStyle | undefined);
+    default:
+      throw new TypeError(`Unknown argument type: ${type as string}`);
+  }
+}

--- a/packages/core/src/msg/arg/date.test.ts
+++ b/packages/core/src/msg/arg/date.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+import { arg } from "../../msg.ts";
+import type { Message } from "../../opaque.ts";
+import { DateTimeArg, type CompiledMessage } from "../../msgfmt.ts";
+
+describe("dateArg", () => {
+  describe("when argStyle is omitted", () => {
+    it("creates a default date argument message", () => {
+      const m = arg("dueDate", "date");
+      expectTypeOf(m).toEqualTypeOf<Message<{ dueDate: Date }>>();
+      expect(m).toEqual<CompiledMessage>(
+        DateTimeArg("dueDate", {
+          year: "numeric",
+          month: "numeric",
+          day: "numeric",
+        }),
+      );
+    });
+  });
+
+  describe("when argStyle is an empty object", () => {
+    it("creates a default date argument message", () => {
+      const m = arg("dueDate", "date", {});
+      expectTypeOf(m).toEqualTypeOf<Message<{ dueDate: Date }>>();
+      expect(m).toEqual<CompiledMessage>(
+        DateTimeArg("dueDate", {
+          year: "numeric",
+          month: "numeric",
+          day: "numeric",
+        }),
+      );
+    });
+  });
+
+  describe("when argStyle is short", () => {
+    it("creates a date argument message with short style", () => {
+      const m = arg("dueDate", "date", "short");
+      expectTypeOf(m).toEqualTypeOf<Message<{ dueDate: Date }>>();
+      expect(m).toEqual<CompiledMessage>(
+        DateTimeArg("dueDate", { dateStyle: "short" }),
+      );
+    });
+  });
+
+  describe("when argStyle is medium", () => {
+    it("creates a date argument message with medium style", () => {
+      const m = arg("dueDate", "date", "medium");
+      expectTypeOf(m).toEqualTypeOf<Message<{ dueDate: Date }>>();
+      expect(m).toEqual<CompiledMessage>(
+        DateTimeArg("dueDate", { dateStyle: "medium" }),
+      );
+    });
+  });
+
+  describe("when argStyle is long", () => {
+    it("creates a date-time argument message with long style", () => {
+      const m = arg("dueDate", "date", "long");
+      expectTypeOf(m).toEqualTypeOf<Message<{ dueDate: Date }>>();
+      expect(m).toEqual<CompiledMessage>(
+        DateTimeArg("dueDate", { dateStyle: "long" }),
+      );
+    });
+  });
+
+  describe("when argStyle is full", () => {
+    it("creates a date-time argument message with full style", () => {
+      const m = arg("dueDate", "date", "full");
+      expectTypeOf(m).toEqualTypeOf<Message<{ dueDate: Date }>>();
+      expect(m).toEqual<CompiledMessage>(
+        DateTimeArg("dueDate", { dateStyle: "full" }),
+      );
+    });
+  });
+
+  describe("when argStyle is an object", () => {
+    it("creates a date-time argument message with given options", () => {
+      const m = arg("dueDate", "date", {
+        year: "2-digit",
+        month: "2-digit",
+        day: "2-digit",
+      });
+      expectTypeOf(m).toEqualTypeOf<Message<{ dueDate: Date }>>();
+      expect(m).toEqual<CompiledMessage>(
+        DateTimeArg("dueDate", {
+          year: "2-digit",
+          month: "2-digit",
+          day: "2-digit",
+        }),
+      );
+    });
+  });
+});

--- a/packages/core/src/msg/arg/date.ts
+++ b/packages/core/src/msg/arg/date.ts
@@ -1,0 +1,40 @@
+import type { Message } from "../../opaque.ts";
+import {
+  dateTimeArg,
+  type ComplexDateTimeArgStyle,
+  type DateArgStyleShorthand,
+} from "./datetime.ts";
+
+export type DateArgStyle = DateArgStyleShorthand | ComplexDateArgStyle;
+export type ComplexDateArgStyle = Pick<
+  ComplexDateTimeArgStyle,
+  "weekday" | "era" | "year" | "month" | "day"
+>;
+
+export function dateArg<const Name extends string | number>(
+  name: Name,
+  argStyle?: DateArgStyle,
+): Message<{ [K in Name]: Date } & { timeZone: string }> {
+  argStyle ??= {};
+  if (typeof argStyle === "string") {
+    return dateTimeArg(name, { dateStyle: argStyle });
+  } else if (typeof argStyle === "object" && argStyle !== null) {
+    const { weekday, era, year, month, day } = argStyle;
+
+    if (
+      weekday == null &&
+      era == null &&
+      year == null &&
+      month == null &&
+      day == null
+    ) {
+      return dateTimeArg(name, {
+        year: "numeric",
+        month: "numeric",
+        day: "numeric",
+      });
+    }
+    return dateTimeArg(name, { weekday, era, year, month, day });
+  }
+  throw new TypeError(`Unknown date argStyle: ${argStyle as string}`);
+}

--- a/packages/core/src/msg/arg/datetime.test.ts
+++ b/packages/core/src/msg/arg/datetime.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+import { arg } from "../../msg.ts";
+import type { Message } from "../../opaque.ts";
+import { DateTimeArg, type CompiledMessage } from "../../msgfmt.ts";
+
+describe("dateTimeArg", () => {
+  describe("when argStyle is omitted", () => {
+    it("creates a default date-time argument message", () => {
+      const m = arg("dueDate", "datetime");
+      expectTypeOf(m).toEqualTypeOf<Message<{ dueDate: Date }>>();
+      expect(m).toEqual<CompiledMessage>(
+        DateTimeArg("dueDate", {
+          year: "numeric",
+          month: "numeric",
+          day: "numeric",
+          hour: "numeric",
+          minute: "numeric",
+          second: "numeric",
+        }),
+      );
+    });
+  });
+
+  describe("when argStyle is an empty object", () => {
+    it("creates a default date-time argument message", () => {
+      const m = arg("dueDate", "datetime", {});
+      expectTypeOf(m).toEqualTypeOf<Message<{ dueDate: Date }>>();
+      expect(m).toEqual<CompiledMessage>(
+        DateTimeArg("dueDate", {
+          year: "numeric",
+          month: "numeric",
+          day: "numeric",
+          hour: "numeric",
+          minute: "numeric",
+          second: "numeric",
+        }),
+      );
+    });
+  });
+
+  describe("when argStyle is short", () => {
+    it("creates a date-time argument message with short style", () => {
+      const m = arg("dueDate", "datetime", "short");
+      expectTypeOf(m).toEqualTypeOf<Message<{ dueDate: Date }>>();
+      expect(m).toEqual<CompiledMessage>(
+        DateTimeArg("dueDate", {
+          dateStyle: "short",
+          timeStyle: "short",
+        }),
+      );
+    });
+  });
+
+  describe("when argStyle is medium", () => {
+    it("creates a date-time argument message with medium style", () => {
+      const m = arg("dueDate", "datetime", "medium");
+      expectTypeOf(m).toEqualTypeOf<Message<{ dueDate: Date }>>();
+      expect(m).toEqual<CompiledMessage>(
+        DateTimeArg("dueDate", {
+          dateStyle: "medium",
+          timeStyle: "medium",
+        }),
+      );
+    });
+  });
+
+  describe("when argStyle is long", () => {
+    it("creates a date-time argument message with long style", () => {
+      const m = arg("dueDate", "datetime", "long");
+      expectTypeOf(m).toEqualTypeOf<Message<{ dueDate: Date }>>();
+      expect(m).toEqual<CompiledMessage>(
+        DateTimeArg("dueDate", {
+          dateStyle: "long",
+          timeStyle: "long",
+        }),
+      );
+    });
+  });
+
+  describe("when argStyle is full", () => {
+    it("creates a date-time argument message with full style", () => {
+      const m = arg("dueDate", "datetime", "full");
+      expectTypeOf(m).toEqualTypeOf<Message<{ dueDate: Date }>>();
+      expect(m).toEqual<CompiledMessage>(
+        DateTimeArg("dueDate", {
+          dateStyle: "full",
+          timeStyle: "full",
+        }),
+      );
+    });
+  });
+
+  describe("when argStyle of a pair of shorthands", () => {
+    it("creates a date-time argument message with given styles", () => {
+      const m = arg("dueDate", "datetime", {
+        dateStyle: "short",
+        timeStyle: "long",
+      });
+      expectTypeOf(m).toEqualTypeOf<Message<{ dueDate: Date }>>();
+      expect(m).toEqual<CompiledMessage>(
+        DateTimeArg("dueDate", {
+          dateStyle: "short",
+          timeStyle: "long",
+        }),
+      );
+    });
+  });
+
+  describe("when argStyle is an object", () => {
+    it("creates a date-time argument message with given options", () => {
+      const m = arg("dueDate", "datetime", {
+        year: "2-digit",
+        month: "2-digit",
+        day: "2-digit",
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+      });
+      expectTypeOf(m).toEqualTypeOf<Message<{ dueDate: Date }>>();
+      expect(m).toEqual<CompiledMessage>(
+        DateTimeArg("dueDate", {
+          year: "2-digit",
+          month: "2-digit",
+          day: "2-digit",
+          hour: "2-digit",
+          minute: "2-digit",
+          second: "2-digit",
+        }),
+      );
+    });
+  });
+});

--- a/packages/core/src/msg/arg/datetime.ts
+++ b/packages/core/src/msg/arg/datetime.ts
@@ -1,0 +1,301 @@
+import { DateTimeArg } from "../../msgfmt.ts";
+import { wrap, type Message } from "../../opaque.ts";
+import {
+  coerceNumberOrUndefined,
+  coerceStringOrUndefined,
+  validateName,
+} from "../util.ts";
+
+export type DateTimeArgStyle =
+  | DateTimeArgStyleShorthand
+  | DateTimeArgShorthandPair
+  | ComplexDateTimeArgStyle;
+export type DateTimeArgShorthandPair =
+  | {
+      timeStyle: TimeArgStyleShorthand;
+      dateStyle?: DateArgStyleShorthand | undefined;
+      era?: undefined;
+      year?: undefined;
+      month?: undefined;
+      day?: undefined;
+      dayPeriod?: undefined;
+      hour?: undefined;
+      minute?: undefined;
+      second?: undefined;
+      fractionalSecondDigits?: undefined;
+      timeZoneName?: undefined;
+    }
+  | {
+      timeStyle?: TimeArgStyleShorthand | undefined;
+      dateStyle: DateArgStyleShorthand;
+      era?: undefined;
+      year?: undefined;
+      month?: undefined;
+      day?: undefined;
+      dayPeriod?: undefined;
+      hour?: undefined;
+      minute?: undefined;
+      second?: undefined;
+      fractionalSecondDigits?: undefined;
+      timeZoneName?: undefined;
+    };
+export type DateArgStyleShorthand = "short" | "medium" | "long" | "full";
+const validDateArgStyleShorthands: Set<DateArgStyleShorthand> = new Set([
+  "short",
+  "medium",
+  "long",
+  "full",
+]);
+export type TimeArgStyleShorthand = "short" | "medium" | "long" | "full";
+const validTimeArgStyleShorthands: Set<TimeArgStyleShorthand> = new Set([
+  "short",
+  "medium",
+  "long",
+  "full",
+]);
+export type DateTimeArgStyleShorthand = DateArgStyleShorthand &
+  TimeArgStyleShorthand;
+export type ComplexDateTimeArgStyle = {
+  timeStyle?: undefined;
+  dateStyle?: undefined;
+  weekday?: WeekdayStyle | undefined;
+  era?: "narrow" | "short" | "long" | undefined;
+  year?: YearStyle | undefined;
+  month?: MonthStyle | undefined;
+  day?: DayStyle | undefined;
+  dayPeriod?: DayPeriodStyle | undefined;
+  hour?: HourStyle | undefined;
+  minute?: MinuteStyle | undefined;
+  second?: SecondStyle | undefined;
+  fractionalSecondDigits?: FractionalSecondDigits | undefined;
+  timeZoneName?: TimeZoneNameStyle | undefined;
+};
+export type WeekdayStyle = "narrow" | "short" | "long";
+const validWeekdayStyles: Set<WeekdayStyle> = new Set([
+  "narrow",
+  "short",
+  "long",
+]);
+export type EraStyle = "narrow" | "short" | "long";
+const validEraStyles: Set<EraStyle> = new Set(["narrow", "short", "long"]);
+export type YearStyle = "2-digit" | "numeric";
+const validYearStyles: Set<YearStyle> = new Set(["2-digit", "numeric"]);
+export type MonthStyle = "2-digit" | "numeric" | "narrow" | "short" | "long";
+const validMonthStyles: Set<MonthStyle> = new Set([
+  "2-digit",
+  "numeric",
+  "narrow",
+  "short",
+  "long",
+]);
+export type DayStyle = "2-digit" | "numeric";
+const validDayStyles: Set<DayStyle> = new Set(["2-digit", "numeric"]);
+export type DayPeriodStyle = "narrow" | "short" | "long";
+const validDayPeriodStyles: Set<DayPeriodStyle> = new Set([
+  "narrow",
+  "short",
+  "long",
+]);
+export type HourStyle = "2-digit" | "numeric";
+const validHourStyles: Set<HourStyle> = new Set(["2-digit", "numeric"]);
+export type MinuteStyle = "2-digit" | "numeric";
+const validMinuteStyles: Set<MinuteStyle> = new Set(["2-digit", "numeric"]);
+export type SecondStyle = "2-digit" | "numeric";
+const validSecondStyles: Set<SecondStyle> = new Set(["2-digit", "numeric"]);
+export type FractionalSecondDigits = 1 | 2 | 3;
+const validFractionalSecondDigits: Set<FractionalSecondDigits> = new Set([
+  1, 2, 3,
+]);
+export type TimeZoneNameStyle =
+  | "short"
+  | "long"
+  | "shortOffset"
+  | "longOffset"
+  | "shortGeneric"
+  | "longGeneric";
+const validTimeZoneNameStyles: Set<TimeZoneNameStyle> = new Set([
+  "short",
+  "long",
+  "shortOffset",
+  "longOffset",
+  "shortGeneric",
+  "longGeneric",
+]);
+
+export function dateTimeArg<const Name extends string | number>(
+  name: Name,
+  argStyle?: DateTimeArgStyle,
+): Message<{ [K in Name]: Date } & { timeZone: string }> {
+  validateName(name);
+  argStyle ??= {};
+  let options: Intl.DateTimeFormatOptions;
+  if (typeof argStyle === "object" && argStyle !== null) {
+    if (argStyle.timeStyle !== undefined || argStyle.dateStyle !== undefined) {
+      let { timeStyle, dateStyle } = argStyle;
+      timeStyle = coerceStringOrUndefined(timeStyle);
+      dateStyle = coerceStringOrUndefined(dateStyle);
+      if (timeStyle != null && !validTimeArgStyleShorthands.has(timeStyle)) {
+        throw new TypeError(
+          `timeStyle must be one of ${Array.from(validTimeArgStyleShorthands).join(", ")}, but got ${timeStyle}`,
+        );
+      }
+      if (dateStyle != null && !validDateArgStyleShorthands.has(dateStyle)) {
+        throw new TypeError(
+          `dateStyle must be one of ${Array.from(validDateArgStyleShorthands).join(", ")}, but got ${dateStyle}`,
+        );
+      }
+      options = { timeStyle, dateStyle };
+    } else {
+      let {
+        weekday,
+        era,
+        year,
+        month,
+        day,
+        dayPeriod,
+        hour,
+        minute,
+        second,
+        fractionalSecondDigits,
+        timeZoneName,
+      } = argStyle;
+      weekday = coerceStringOrUndefined(weekday);
+      era = coerceStringOrUndefined(era);
+      year = coerceStringOrUndefined(year);
+      month = coerceStringOrUndefined(month);
+      day = coerceStringOrUndefined(day);
+      dayPeriod = coerceStringOrUndefined(dayPeriod);
+      hour = coerceStringOrUndefined(hour);
+      minute = coerceStringOrUndefined(minute);
+      second = coerceStringOrUndefined(second);
+      fractionalSecondDigits = coerceNumberOrUndefined(fractionalSecondDigits);
+      timeZoneName = coerceStringOrUndefined(timeZoneName);
+      if (weekday != null && !validWeekdayStyles.has(weekday)) {
+        throw new TypeError(
+          `weekday must be one of ${Array.from(validWeekdayStyles).join(
+            ", ",
+          )}, but got ${weekday as string}`,
+        );
+      }
+      if (era != null && !validEraStyles.has(era)) {
+        throw new TypeError(
+          `era must be one of ${Array.from(validEraStyles).join(
+            ", ",
+          )}, but got ${era as string}`,
+        );
+      }
+      if (year != null && !validYearStyles.has(year)) {
+        throw new TypeError(
+          `year must be one of ${Array.from(validYearStyles).join(
+            ", ",
+          )}, but got ${year as string}`,
+        );
+      }
+      if (month != null && !validMonthStyles.has(month)) {
+        throw new TypeError(
+          `month must be one of ${Array.from(validMonthStyles).join(
+            ", ",
+          )}, but got ${month as string}`,
+        );
+      }
+      if (day != null && !validDayStyles.has(day)) {
+        throw new TypeError(
+          `day must be one of ${Array.from(validDayStyles).join(
+            ", ",
+          )}, but got ${day as string}`,
+        );
+      }
+      if (dayPeriod != null && !validDayPeriodStyles.has(dayPeriod)) {
+        throw new TypeError(
+          `dayPeriod must be one of ${Array.from(validDayPeriodStyles).join(
+            ", ",
+          )}, but got ${dayPeriod as string}`,
+        );
+      }
+      if (hour != null && !validHourStyles.has(hour)) {
+        throw new TypeError(
+          `hour must be one of ${Array.from(validHourStyles).join(
+            ", ",
+          )}, but got ${hour as string}`,
+        );
+      }
+      if (minute != null && !validMinuteStyles.has(minute)) {
+        throw new TypeError(
+          `minute must be one of ${Array.from(validMinuteStyles).join(
+            ", ",
+          )}, but got ${minute as string}`,
+        );
+      }
+      if (second != null && !validSecondStyles.has(second)) {
+        throw new TypeError(
+          `second must be one of ${Array.from(validSecondStyles).join(
+            ", ",
+          )}, but got ${second as string}`,
+        );
+      }
+      if (
+        fractionalSecondDigits != null &&
+        !validFractionalSecondDigits.has(fractionalSecondDigits)
+      ) {
+        throw new RangeError(
+          `fractionalSecondDigits must be one of ${Array.from(
+            validFractionalSecondDigits,
+          ).join(", ")}, but got ${fractionalSecondDigits}`,
+        );
+      }
+      if (timeZoneName != null && !validTimeZoneNameStyles.has(timeZoneName)) {
+        throw new TypeError(
+          `timeZoneName must be one of ${Array.from(
+            validTimeZoneNameStyles,
+          ).join(", ")}, but got ${timeZoneName as string}`,
+        );
+      }
+      if (
+        weekday == null &&
+        year == null &&
+        month == null &&
+        day == null &&
+        dayPeriod == null &&
+        hour == null &&
+        minute == null &&
+        second == null &&
+        fractionalSecondDigits == null
+      ) {
+        if (era != null || timeZoneName != null) {
+          throw new TypeError(
+            `At least one of weekday, year, month, day, dayPeriod, hour, minute, second, fractionalSecondDigits must be specified`,
+          );
+        } else {
+          // Default to full date and time if nothing is specified
+          year = "numeric";
+          month = "numeric";
+          day = "numeric";
+          hour = "numeric";
+          minute = "numeric";
+          second = "numeric";
+        }
+      }
+      options = {
+        weekday,
+        era,
+        year,
+        month,
+        day,
+        dayPeriod,
+        hour,
+        minute,
+        second,
+        fractionalSecondDigits,
+        timeZoneName,
+      };
+    }
+  } else if (
+    validDateArgStyleShorthands.has(argStyle as DateArgStyleShorthand) &&
+    validTimeArgStyleShorthands.has(argStyle as TimeArgStyleShorthand)
+  ) {
+    options = { dateStyle: argStyle, timeStyle: argStyle };
+  } else {
+    throw new TypeError(`Unknown number argStyle: ${argStyle as string}`);
+  }
+  return wrap(DateTimeArg(name, options));
+}

--- a/packages/core/src/msg/arg/number.test.ts
+++ b/packages/core/src/msg/arg/number.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+import { arg } from "../../msg.ts";
+import type { Message } from "../../opaque.ts";
+import { NumberArg, type CompiledMessage } from "../../msgfmt.ts";
+
+describe("numberArg", () => {
+  describe("when argStyle is omitted", () => {
+    it("creates a number argument message", () => {
+      const m = arg("age", "number");
+      expectTypeOf(m).toEqualTypeOf<Message<{ age: number | bigint }>>();
+      expect(m).toEqual<CompiledMessage>(NumberArg("age", {}));
+    });
+  });
+
+  describe("when argStyle is number", () => {
+    it("creates a number argument message", () => {
+      const m = arg("age", "number", "number");
+      expectTypeOf(m).toEqualTypeOf<Message<{ age: number | bigint }>>();
+      expect(m).toEqual<CompiledMessage>(NumberArg("age", {}));
+    });
+  });
+
+  describe("when argStyle is integer", () => {
+    it("creates a number argument message with integer style", () => {
+      const m = arg("age", "number", "integer");
+      expectTypeOf(m).toEqualTypeOf<Message<{ age: number | bigint }>>();
+      expect(m).toEqual<CompiledMessage>(
+        NumberArg("age", {
+          maximumFractionDigits: 0,
+        }),
+      );
+    });
+  });
+
+  describe("when argStyle is percent", () => {
+    it("creates a number argument message with percent style", () => {
+      const m = arg("progress", "number", "percent");
+      expectTypeOf(m).toEqualTypeOf<Message<{ progress: number | bigint }>>();
+      expect(m).toEqual<CompiledMessage>(
+        NumberArg("progress", {
+          style: "percent",
+        }),
+      );
+    });
+  });
+
+  describe("when argStyle is object", () => {
+    it("creates a number argument message with given options", () => {
+      const m = arg("age", "number", {
+        style: "decimal",
+        minimumIntegerDigits: 2,
+      });
+      expectTypeOf(m).toEqualTypeOf<Message<{ age: number | bigint }>>();
+      expect(m).toEqual<CompiledMessage>(
+        NumberArg("age", {
+          style: "decimal",
+          minimumIntegerDigits: 2,
+        }),
+      );
+    });
+
+    it("creates a number argument message with given subtract option", () => {
+      const m = arg("count", "number", {
+        style: "decimal",
+        subtract: 2,
+      });
+      expectTypeOf(m).toEqualTypeOf<Message<{ count: number | bigint }>>();
+      expect(m).toEqual<CompiledMessage>(
+        NumberArg(
+          "count",
+          {
+            style: "decimal",
+          },
+          { subtract: 2 },
+        ),
+      );
+    });
+  });
+});

--- a/packages/core/src/msg/arg/number.ts
+++ b/packages/core/src/msg/arg/number.ts
@@ -1,0 +1,266 @@
+import { NumberArg } from "../../msgfmt.ts";
+import { wrap, type Message } from "../../opaque.ts";
+import {
+  coerceNumberOrUndefined,
+  coerceStringOrUndefined,
+  validateName,
+} from "../util.ts";
+
+export type NumberArgStyle = SimpleNumberArgStyle | ComplexNumberArgStyle;
+export type SimpleNumberArgStyle = "number" | "integer" | "percent";
+export type ComplexNumberArgStyle = {
+  subtract?: number;
+  style?: "decimal" | "percent" | undefined;
+  minimumIntegerDigits?: number | undefined;
+  minimumFractionDigits?: number | undefined;
+  maximumFractionDigits?: number | undefined;
+  minimumSignificantDigits?: number | undefined;
+  maximumSignificantDigits?: number | undefined;
+  roundingPriority?: RoundingPriority | undefined;
+  roundingIncrement?: RoundingIncrement | undefined;
+  roundingMode?: RoundingMode | undefined;
+  trailingZeroDisplay?: TrailingZeroDisplay | undefined;
+  notation?: NumberNotation | undefined;
+  compactDisplay?: NumberCompactDisplay | undefined;
+  useGrouping?: UseGrouping | undefined;
+  signDisplay?: SignDisplay | undefined;
+};
+export type RoundingPriority = "auto" | "morePrecision" | "lessPrecision";
+export type RoundingIncrement =
+  | 1
+  | 2
+  | 5
+  | 10
+  | 20
+  | 25
+  | 50
+  | 100
+  | 200
+  | 250
+  | 500
+  | 1000
+  | 2000
+  | 2500
+  | 5000;
+const validRoundingIncrements: Set<RoundingIncrement> = new Set([
+  1, 2, 5, 10, 20, 25, 50, 100, 200, 250, 500, 1000, 2000, 2500, 5000,
+]);
+
+export type RoundingMode =
+  | "ceil"
+  | "floor"
+  | "expand"
+  | "trunc"
+  | "halfCeil"
+  | "halfFloor"
+  | "halfExpand"
+  | "halfTrunc"
+  | "halfEven";
+const validRoundingModes: Set<RoundingMode> = new Set([
+  "ceil",
+  "floor",
+  "expand",
+  "trunc",
+  "halfCeil",
+  "halfFloor",
+  "halfExpand",
+  "halfTrunc",
+  "halfEven",
+]);
+
+export type TrailingZeroDisplay = "auto" | "stripIfInteger";
+const validTrailingZeroDisplays: Set<TrailingZeroDisplay> = new Set([
+  "auto",
+  "stripIfInteger",
+]);
+
+export type NumberNotation =
+  | "standard"
+  | "scientific"
+  | "engineering"
+  | "compact";
+const validNumberNotations: Set<NumberNotation> = new Set([
+  "standard",
+  "scientific",
+  "engineering",
+  "compact",
+]);
+
+export type NumberCompactDisplay = "short" | "long";
+const validNumberCompactDisplays: Set<NumberCompactDisplay> = new Set([
+  "short",
+  "long",
+]);
+export type UseGrouping = boolean | "min2" | "auto" | "always";
+const validUseGroupings: Set<UseGrouping> = new Set([
+  true,
+  false,
+  "min2",
+  "auto",
+  "always",
+]);
+
+export type SignDisplay =
+  | "auto"
+  | "never"
+  | "always"
+  | "exceptZero"
+  | "negative";
+const validSignDisplays: Set<SignDisplay> = new Set([
+  "auto",
+  "never",
+  "always",
+  "exceptZero",
+  "negative",
+]);
+
+export function numberArg<const Name extends string | number>(
+  name: Name,
+  argStyle: NumberArgStyle = "number",
+): Message<{ [K in Name]: number | bigint }> {
+  validateName(name);
+  let subtract: number = 0;
+  let options: Intl.NumberFormatOptions;
+  if (typeof argStyle === "object" && argStyle !== null) {
+    let {
+      style = "decimal",
+      minimumIntegerDigits,
+      minimumFractionDigits,
+      maximumFractionDigits,
+      minimumSignificantDigits,
+      maximumSignificantDigits,
+      roundingPriority,
+      roundingIncrement,
+      roundingMode,
+      trailingZeroDisplay,
+      notation,
+      compactDisplay,
+      useGrouping,
+      signDisplay,
+    } = argStyle;
+
+    subtract = +(argStyle.subtract ?? 0);
+    style = `${style}`;
+    minimumIntegerDigits = coerceNumberOrUndefined(minimumIntegerDigits);
+    minimumFractionDigits = coerceNumberOrUndefined(minimumFractionDigits);
+    maximumFractionDigits = coerceNumberOrUndefined(maximumFractionDigits);
+    minimumSignificantDigits = coerceNumberOrUndefined(
+      minimumSignificantDigits,
+    );
+    maximumSignificantDigits = coerceNumberOrUndefined(
+      maximumSignificantDigits,
+    );
+    roundingPriority = coerceStringOrUndefined(roundingPriority);
+    roundingIncrement = coerceNumberOrUndefined(roundingIncrement);
+    roundingMode = coerceStringOrUndefined(roundingMode);
+    trailingZeroDisplay = coerceStringOrUndefined(trailingZeroDisplay);
+    notation = coerceStringOrUndefined(notation);
+    compactDisplay = coerceStringOrUndefined(compactDisplay);
+    if (typeof useGrouping !== "boolean") {
+      useGrouping = coerceStringOrUndefined(useGrouping);
+    }
+    signDisplay = coerceStringOrUndefined(signDisplay);
+
+    if (!Number.isInteger(subtract) || subtract < 0) {
+      throw new RangeError(
+        `subtract must be a non-negative integer, but got ${subtract}`,
+      );
+    }
+    if (style !== "decimal" && style !== "percent") {
+      throw new TypeError(
+        `style must be "decimal" or "percent", but got ${style as string}`,
+      );
+    }
+    if (
+      minimumIntegerDigits != null &&
+      (minimumIntegerDigits < 1 || minimumIntegerDigits > 21)
+    ) {
+      throw new RangeError(
+        `minimumIntegerDigits must be between 1 and 21, but got ${minimumIntegerDigits}`,
+      );
+    }
+    if (
+      roundingIncrement != null &&
+      !validRoundingIncrements.has(roundingIncrement)
+    ) {
+      throw new RangeError(
+        `roundingIncrement must be one of ${Array.from(
+          validRoundingIncrements,
+        ).join(", ")}, but got ${roundingIncrement}`,
+      );
+    }
+    if (roundingMode != null && !validRoundingModes.has(roundingMode)) {
+      throw new RangeError(
+        `roundingMode must be one of ${Array.from(validRoundingModes).join(
+          ", ",
+        )}, but got ${roundingMode as string}`,
+      );
+    }
+    if (
+      trailingZeroDisplay != null &&
+      !validTrailingZeroDisplays.has(trailingZeroDisplay)
+    ) {
+      throw new RangeError(
+        `trailingZeroDisplay must be one of ${Array.from(
+          validTrailingZeroDisplays,
+        ).join(", ")}, but got ${trailingZeroDisplay as string}`,
+      );
+    }
+    if (notation != null && !validNumberNotations.has(notation)) {
+      throw new RangeError(
+        `notation must be one of ${Array.from(validNumberNotations).join(
+          ", ",
+        )}, but got ${notation as string}`,
+      );
+    }
+    if (
+      compactDisplay != null &&
+      !validNumberCompactDisplays.has(compactDisplay)
+    ) {
+      throw new RangeError(
+        `compactDisplay must be one of ${Array.from(
+          validNumberCompactDisplays,
+        ).join(", ")}, but got ${compactDisplay as string}`,
+      );
+    }
+    if (useGrouping != null && !validUseGroupings.has(useGrouping)) {
+      throw new RangeError(
+        `useGrouping must be one of ${Array.from(validUseGroupings).join(
+          ", ",
+        )}, but got ${useGrouping as string}`,
+      );
+    }
+    if (signDisplay != null && !validSignDisplays.has(signDisplay)) {
+      throw new RangeError(
+        `signDisplay must be one of ${Array.from(validSignDisplays).join(
+          ", ",
+        )}, but got ${signDisplay as string}`,
+      );
+    }
+    options = {
+      style,
+      minimumIntegerDigits,
+      minimumFractionDigits,
+      maximumFractionDigits,
+      minimumSignificantDigits,
+      maximumSignificantDigits,
+      roundingPriority,
+      roundingIncrement,
+      roundingMode,
+      trailingZeroDisplay,
+      notation,
+      compactDisplay,
+      useGrouping,
+      signDisplay,
+    };
+  } else if (argStyle === "number" || argStyle == null) {
+    options = {};
+  } else if (argStyle === "integer") {
+    options = { maximumFractionDigits: 0 };
+  } else if (argStyle === "percent") {
+    options = { style: "percent" };
+  } else {
+    throw new TypeError(`Unknown number argStyle: ${argStyle as string}`);
+  }
+  return wrap(NumberArg(name, options, { subtract }));
+}

--- a/packages/core/src/msg/arg/string.test.ts
+++ b/packages/core/src/msg/arg/string.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+import { arg } from "../../msg.ts";
+import type { Message } from "../../opaque.ts";
+import { StringArg, type CompiledMessage } from "../../msgfmt.ts";
+
+describe("stringArg", () => {
+  it("creates a string argument message", () => {
+    const m = arg("username", "string");
+    expectTypeOf(m).toEqualTypeOf<Message<{ username: string }>>();
+    expect(m).toEqual<CompiledMessage>(StringArg("username"));
+  });
+});

--- a/packages/core/src/msg/arg/string.ts
+++ b/packages/core/src/msg/arg/string.ts
@@ -1,0 +1,10 @@
+import { StringArg } from "../../msgfmt.ts";
+import { wrap, type Message } from "../../opaque.ts";
+import { validateName } from "../util.ts";
+
+export function stringArg<const Name extends string | number>(
+  name: Name,
+): Message<{ [K in Name]: string }> {
+  validateName(name);
+  return wrap(StringArg(name));
+}

--- a/packages/core/src/msg/arg/time.test.ts
+++ b/packages/core/src/msg/arg/time.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+import { arg } from "../../msg.ts";
+import type { Message } from "../../opaque.ts";
+import { DateTimeArg, type CompiledMessage } from "../../msgfmt.ts";
+
+describe("timeArg", () => {
+  describe("when argStyle is omitted", () => {
+    it("creates a default time argument message", () => {
+      const m = arg("dueDate", "time");
+      expectTypeOf(m).toEqualTypeOf<Message<{ dueDate: Date }>>();
+      expect(m).toEqual<CompiledMessage>(
+        DateTimeArg("dueDate", {
+          hour: "numeric",
+          minute: "numeric",
+          second: "numeric",
+        }),
+      );
+    });
+  });
+
+  describe("when argStyle is an empty object", () => {
+    it("creates a default time argument message", () => {
+      const m = arg("dueDate", "time", {});
+      expectTypeOf(m).toEqualTypeOf<Message<{ dueDate: Date }>>();
+      expect(m).toEqual<CompiledMessage>(
+        DateTimeArg("dueDate", {
+          hour: "numeric",
+          minute: "numeric",
+          second: "numeric",
+        }),
+      );
+    });
+  });
+
+  describe("when argStyle is short", () => {
+    it("creates a time argument message with short style", () => {
+      const m = arg("dueDate", "time", "short");
+      expectTypeOf(m).toEqualTypeOf<Message<{ dueDate: Date }>>();
+      expect(m).toEqual<CompiledMessage>(
+        DateTimeArg("dueDate", { timeStyle: "short" }),
+      );
+    });
+  });
+
+  describe("when argStyle is medium", () => {
+    it("creates a time argument message with medium style", () => {
+      const m = arg("dueDate", "time", "medium");
+      expectTypeOf(m).toEqualTypeOf<Message<{ dueDate: Date }>>();
+      expect(m).toEqual<CompiledMessage>(
+        DateTimeArg("dueDate", { timeStyle: "medium" }),
+      );
+    });
+  });
+
+  describe("when argStyle is long", () => {
+    it("creates a time argument message with long style", () => {
+      const m = arg("dueDate", "time", "long");
+      expectTypeOf(m).toEqualTypeOf<Message<{ dueDate: Date }>>();
+      expect(m).toEqual<CompiledMessage>(
+        DateTimeArg("dueDate", { timeStyle: "long" }),
+      );
+    });
+  });
+
+  describe("when argStyle is full", () => {
+    it("creates a time argument message with full style", () => {
+      const m = arg("dueDate", "time", "full");
+      expectTypeOf(m).toEqualTypeOf<Message<{ dueDate: Date }>>();
+      expect(m).toEqual<CompiledMessage>(
+        DateTimeArg("dueDate", { timeStyle: "full" }),
+      );
+    });
+  });
+
+  describe("when argStyle is an object", () => {
+    it("creates a time argument message with given options", () => {
+      const m = arg("dueDate", "time", {
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+      });
+      expectTypeOf(m).toEqualTypeOf<Message<{ dueDate: Date }>>();
+      expect(m).toEqual<CompiledMessage>(
+        DateTimeArg("dueDate", {
+          hour: "2-digit",
+          minute: "2-digit",
+          second: "2-digit",
+        }),
+      );
+    });
+  });
+});

--- a/packages/core/src/msg/arg/time.ts
+++ b/packages/core/src/msg/arg/time.ts
@@ -1,0 +1,61 @@
+import type { Message } from "../../opaque.ts";
+import {
+  dateTimeArg,
+  type ComplexDateTimeArgStyle,
+  type TimeArgStyleShorthand,
+} from "./datetime.ts";
+
+export type TimeArgStyle = TimeArgStyleShorthand | ComplexTimeArgStyle;
+export type ComplexTimeArgStyle = Pick<
+  ComplexDateTimeArgStyle,
+  | "dayPeriod"
+  | "hour"
+  | "minute"
+  | "second"
+  | "fractionalSecondDigits"
+  | "timeZoneName"
+>;
+
+export function timeArg<const Name extends string | number>(
+  name: Name,
+  argStyle?: TimeArgStyle,
+): Message<{ [K in Name]: Date } & { timeZone: string }> {
+  argStyle ??= {};
+  if (typeof argStyle === "string") {
+    return dateTimeArg(name, { timeStyle: argStyle });
+  } else if (typeof argStyle === "object" && argStyle != null) {
+    const {
+      dayPeriod,
+      hour,
+      minute,
+      second,
+      fractionalSecondDigits,
+      timeZoneName,
+    } = argStyle;
+
+    if (
+      dayPeriod == null &&
+      hour == null &&
+      minute == null &&
+      second == null &&
+      fractionalSecondDigits == null &&
+      timeZoneName == null
+    ) {
+      return dateTimeArg(name, {
+        hour: "numeric",
+        minute: "numeric",
+        second: "numeric",
+      });
+    }
+
+    return dateTimeArg(name, {
+      dayPeriod,
+      hour,
+      minute,
+      second,
+      fractionalSecondDigits,
+      timeZoneName,
+    });
+  }
+  throw new TypeError(`Unknown time argStyle: ${argStyle as string}`);
+}

--- a/packages/core/src/msg/branch.ts
+++ b/packages/core/src/msg/branch.ts
@@ -1,0 +1,62 @@
+import type { Message } from "../opaque.ts";
+
+/**
+ * An intermediary builder for constructing a branch message, such as `plural`.
+ *
+ * @since 0.2.1 (`@hi18n/core`)
+ */
+export type BranchBuilder<Options extends string | number> = {
+  branch: <const Branches extends BranchesBase<Options, Message<never>>>(
+    ...branches: Branches
+  ) => Message<
+    Branches extends BranchesBase<Options, Message<infer T>>
+      ? { [K in keyof T]: T[K] }
+      : never
+  >;
+};
+
+/**
+ * @since 0.2.1 (`@hi18n/core`)
+ */
+export type BranchesBase<Options extends string | number, M> = [
+  ...When<Options, M>[],
+  Otherwise<M>,
+];
+
+/**
+ * @since 0.2.1 (`@hi18n/core`)
+ */
+export type When<Condition extends string | number, M> = {
+  type: "When";
+  when: Condition;
+  message: M;
+};
+
+/**
+ * A DSL function used as part of a branch message, such as `plural`.
+ *
+ * @since 0.2.1 (`@hi18n/core`)
+ */
+export function when<Condition extends string | number, M>(
+  when: Condition,
+  message: M,
+): When<Condition, M> {
+  return { type: "When", when, message };
+}
+
+/**
+ * @since 0.2.1 (`@hi18n/core`)
+ */
+export type Otherwise<M> = {
+  type: "Otherwise";
+  message: M;
+};
+
+/**
+ * A DSL function used as part of a branch message, such as `plural`.
+ *
+ * @since 0.2.1 (`@hi18n/core`)
+ */
+export function otherwise<M>(message: M): Otherwise<M> {
+  return { type: "Otherwise", message };
+}

--- a/packages/core/src/msg/mf1.ts
+++ b/packages/core/src/msg/mf1.ts
@@ -1,0 +1,28 @@
+import type { InferredMessageType } from "../msgfmt-parser-types.ts";
+import { parseMessage } from "../msgfmt-parser.ts";
+import { destringify } from "../msgfmt.ts";
+import { wrap } from "../opaque.ts";
+
+/**
+ * Wraps an ICU MessageFormat 1.0 message string in a wrapper object.
+ *
+ * Equivalent to `msg(...)` exported from `@hi18n/core`, except:
+ *
+ * - It does not defer parse errors, unlike `msg(...)`.
+ * - It does not contain overloads for ``msg`...` `` tagged templates.
+ *
+ * @param s the translated message
+ * @returns the first argument
+ *
+ * @since 0.2.1 (`@hi18n/core`)
+ *
+ * @example
+ *   ```ts
+ *   export default new Book<Vocabulary>({
+ *     "example/greeting": mf1("Hello, {name}!"),
+ *   });
+ *   ```
+ */
+export function mf1<S extends string>(s: S): InferredMessageType<S> {
+  return wrap(destringify(parseMessage(s))) as InferredMessageType<S>;
+}

--- a/packages/core/src/msg/plural.test.ts
+++ b/packages/core/src/msg/plural.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+import { plural } from "./plural.ts";
+import { otherwise, when } from "./branch.ts";
+import { msg } from "./tagged-template.ts";
+import { arg } from "../msg.ts";
+import type { Message } from "../opaque.ts";
+import {
+  type CompiledMessage,
+  PluralArg,
+  PluralBranch,
+  StringArg,
+} from "../msgfmt.ts";
+
+describe("plural", () => {
+  it("generates one branch", () => {
+    const m = plural("count").branch(otherwise(msg`foo${arg("foo")}`));
+    expectTypeOf(m).toEqualTypeOf<Message<{ foo: string }>>();
+    expect(m).toEqual<CompiledMessage>(
+      PluralArg("count", [], ["foo", StringArg("foo")]),
+    );
+  });
+
+  it("generates multiple branches", () => {
+    const m = plural("count").branch(
+      when("one", msg`one${arg("one")}`),
+      when(2, msg`two${arg("two")}`),
+      otherwise(msg`other${arg("other")}`),
+    );
+    expectTypeOf(m).toEqualTypeOf<
+      Message<{ one: string; two: string; other: string }>
+    >();
+    expect(m).toEqual<CompiledMessage>(
+      PluralArg(
+        "count",
+        [
+          PluralBranch("one", ["one", StringArg("one")]),
+          PluralBranch(2, ["two", StringArg("two")]),
+        ],
+        ["other", StringArg("other")],
+      ),
+    );
+  });
+
+  it("generates branches with subtract option", () => {
+    const m = plural("count", { subtract: 1 }).branch(
+      when("one", msg`one${arg("one")}`),
+      when(2, msg`two${arg("two")}`),
+      otherwise(msg`other${arg("other")}`),
+    );
+    expectTypeOf(m).toEqualTypeOf<
+      Message<{ one: string; two: string; other: string }>
+    >();
+    expect(m).toEqual<CompiledMessage>(
+      PluralArg(
+        "count",
+        [
+          PluralBranch("one", ["one", StringArg("one")]),
+          PluralBranch(2, ["two", StringArg("two")]),
+        ],
+        ["other", StringArg("other")],
+        { subtract: 1 },
+      ),
+    );
+  });
+});

--- a/packages/core/src/msg/plural.ts
+++ b/packages/core/src/msg/plural.ts
@@ -1,0 +1,160 @@
+import { PluralArg, PluralBranch } from "../msgfmt.ts";
+import { unwrap, wrap, type Message } from "../opaque.ts";
+import type { BranchBuilder, BranchesBase, When } from "./branch.ts";
+import { validateName } from "./util.ts";
+
+// "other" is excluded as it should be handled by otherwise().
+/**
+ * Plural categories defined in [CLDR](https://cldr.unicode.org/index/cldr-spec/plural-rules),
+ * except "other".
+ *
+ * Note that "zero" and 0 are different conditions.
+ * Similarly, "one" and 1 are different conditions and "two" and 2 are different conditions.
+ *
+ * For English cardinal plurals, only "one" and "other" are used.
+ *
+ * - "one" is used for singular forms (e.g. 1 item).
+ * - "other" is used for plural forms (e.g. 0, 2, or more items).
+ *
+ * For English ordinal plurals, "one", "two", "few", and "other" are used.
+ *
+ * - "one" is used for "-st".
+ * - "two" is used for "-nd".
+ * - "few" is used for "-rd".
+ * - "other" is used for "-th".
+ *
+ * @since 0.2.1 (`@hi18n/core`)
+ */
+export type PluralType = "zero" | "one" | "two" | "few" | "many";
+const validPluralTypes: Set<PluralType> = new Set([
+  "zero",
+  "one",
+  "two",
+  "few",
+  "many",
+]);
+
+/**
+ * @since 0.2.1 (`@hi18n/core`)
+ */
+export type PluralOptions = {
+  /**
+   * The value to subtract from the number before determining the plural category.
+   *
+   * Note that subtraction only applies to plural category selection,
+   * not to exact number match (e.g. `when(0, ...)`).
+   */
+  subtract?: number;
+};
+
+/**
+ * Initiates a plural branch.
+ *
+ * In plural branches, one can specify three types of branches:
+ *
+ * - `when(number, message)`: for exact number match.
+ * - `when(pluralType, message)`: for plural category match. The categories are:
+ *   - `zero` for languages that distinguishes it (English cardinals do not).
+ *     Typically used for 0, but not limited to it (e.g. cardinal 10 in Latvian).
+ *   - `one` for languages that distinguishes it.
+ *     Typically used for 1, but not limited to it (e.g. cardinal 21 in Russian).
+ *   - `two` for languages that distinguishes it (English cardinals do not).
+ *     Typically used for 2, but not limited to it (e.g. ordinal 22 in English).
+ *   - `few` for languages that distinguishes it (English cardinals do not).
+ *     Typically used for small counts (e.g. 3, 4), but not limited to them (e.g. cardinal 1004 in Russian).
+ *   - `many` for languages that distinguishes it (English cardinals do not).
+ *     Typically used for a bit larger counts (e.g. 5 and above), but not limited to them (e.g. cardinal 1011 in Arabic).
+ *   - `other` for all languages, but you cannot specify it here.
+ *     Use `otherwise()` instead.
+ * - `otherwise(message)`: mandatory catch-all branch.
+ *
+ * For English:
+ *
+ * - For cardinal plurals, use `one` for singular and `otherwise()` for plural.
+ * - For ordinal plurals, use `one`, `two`, `few` for `-st`, `-nd`, `-rd` respectively, and `otherwise()` for `-th`.
+ *
+ * See [Language Plural Rules](https://www.unicode.org/cldr/charts/47/supplemental/language_plural_rules.html)
+ * for details about plural rules in various languages.
+ *
+ * @param name The name of the number-valued parameter used for plural selection.
+ * @param options the options.
+ * @returns the branch builder that can be used to define branches.
+ *
+ * @since 0.2.1 (`@hi18n/core`)
+ *
+ * @example
+ *   ```ts
+ *   const catalogEn = new Catalog<Vocabulary>("en", {
+ *     itemCount: plural("count").branch(
+ *       when("one", msg`${arg("count", "number")} item`),
+ *       otherwise(msg`${arg("count", "number")} items`),
+ *     ),
+ *   });
+ *   ```
+ */
+export function plural(
+  name: string | number,
+  options: PluralOptions = {},
+): BranchBuilder<PluralType | number> {
+  const { subtract = 0 } = options;
+  validateName(name);
+
+  return {
+    branch: <
+      const Branches extends BranchesBase<PluralType | number, Message<never>>,
+    >(
+      ...branches: Branches
+    ): Message<
+      Branches extends BranchesBase<PluralType | number, Message<infer T>>
+        ? { [K in keyof T]: T[K] }
+        : never
+    > => {
+      if (
+        branches.length === 0 ||
+        branches[branches.length - 1]!.type !== "Otherwise"
+      ) {
+        throw new TypeError(`The last branch must be otherwise() branch`);
+      }
+      const whenBranches = branches.slice(0, -1);
+      const lastBranch = branches[branches.length - 1]!;
+      const seen = new Set<PluralType | number>();
+      for (const branch of whenBranches) {
+        if (branch.type !== "When") {
+          throw new TypeError(`Only the last branch can be otherwise()`);
+        }
+        validateCondition(branch.when);
+        if (seen.has(branch.when)) {
+          throw new TypeError(`Duplicate plural condition: ${branch.when}`);
+        }
+        seen.add(branch.when);
+      }
+      return wrap(
+        PluralArg(
+          name,
+          (whenBranches as When<PluralType | number, Message<never>>[]).map(
+            ({ when, message }): PluralBranch => ({
+              selector: when,
+              message: unwrap(message),
+            }),
+          ),
+          unwrap(lastBranch.message),
+          { subtract },
+        ),
+      );
+    },
+  };
+}
+
+function validateCondition(condition: string | number): void {
+  if (typeof condition === "string") {
+    if (!validPluralTypes.has(condition as PluralType)) {
+      throw new TypeError(`Invalid plural condition: ${condition}`);
+    }
+  } else if (typeof condition === "number") {
+    if (!Number.isInteger(condition) || condition < 0) {
+      throw new TypeError(`Invalid plural condition: ${condition}`);
+    }
+  } else {
+    throw new TypeError(`Invalid plural condition: ${condition as string}`);
+  }
+}

--- a/packages/core/src/msg/tag.ts
+++ b/packages/core/src/msg/tag.ts
@@ -1,0 +1,40 @@
+import { ElementArg } from "../msgfmt.ts";
+import {
+  unwrap,
+  wrap,
+  type ComponentPlaceholder,
+  type Message,
+} from "../opaque.ts";
+import { validateName } from "./util.ts";
+
+/**
+ * An intermediary builder for constructing a marked-up message.
+ *
+ * @since 0.2.1 (`@hi18n/core`)
+ */
+export type ElementBuilder<Name extends string | number> = <Args>(
+  submessage?: Message<Args>,
+) => Message<Args & { [K in Name]: ComponentPlaceholder }>;
+
+/**
+ * Builds a marked-up message that would be expanded in some way
+ * to the real markup (e.g., HTML, XML, React/Vue components, etc.).
+ *
+ * @param name the name of the argument representing the element
+ * @returns a builder function that takes a submessage
+ *
+ * @since 0.2.1 (`@hi18n/core`)
+ *
+ * @example
+ *   ```ts
+ *   const catalogEn = new Catalog<Vocabulary>("en", {
+ *    greeting: msg`Hello, ${tag("strong")(msg`${arg("name")}`)}!`,
+ *  });
+ *   ```
+ */
+export function tag<const Name extends string | number>(
+  name: Name,
+): ElementBuilder<Name> {
+  validateName(name);
+  return (submessage) => wrap(ElementArg(name, unwrap(submessage!)));
+}

--- a/packages/core/src/msg/tagged-template.test.ts
+++ b/packages/core/src/msg/tagged-template.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+import { msg, arg } from "../msg.ts";
+import { NumberArg, StringArg, type CompiledMessage } from "../msgfmt.ts";
+import type { Message } from "../opaque.ts";
+
+describe("msg tag", () => {
+  it("emits empty string for empty message", () => {
+    const m = msg``;
+    expectTypeOf(m).toEqualTypeOf<Message>();
+    expect(m).toEqual<CompiledMessage>([""]);
+  });
+
+  it("emits simple string", () => {
+    const m = msg`Hello, World!`;
+    expectTypeOf(m).toEqualTypeOf<Message>();
+    expect(m).toEqual<CompiledMessage>(["Hello, World!"]);
+  });
+
+  it("does not interpret MessageFormat escapes", () => {
+    const m = msg`Hello, {name}! I''m John.`;
+    expectTypeOf(m).toEqualTypeOf<Message>();
+    expect(m).toEqual<CompiledMessage>(["Hello, {name}! I''m John."]);
+  });
+
+  it("concatenates string-valued interpolations", () => {
+    const name = "Alice";
+    const m = msg`Hello, ${name as unknown as Message<unknown>}!`;
+    expectTypeOf(m).toEqualTypeOf<Message>();
+    expect(m).toEqual<CompiledMessage>(["Hello, Alice!"]);
+  });
+
+  it("concatenates array-of-strings-valued interpolations", () => {
+    const items = ["apples, ", "bananas, ", "cherries"];
+    const m = msg`I like ${items as unknown as Message<unknown>}!`;
+    expectTypeOf(m).toEqualTypeOf<Message>();
+    expect(m).toEqual<CompiledMessage>(["I like apples, bananas, cherries!"]);
+  });
+
+  it("interpolates multiple arguments", () => {
+    const m = msg`Name: ${arg("name")}, Age: ${arg("age", "number")}`;
+    expectTypeOf(m).toEqualTypeOf<
+      Message<{ name: string; age: number | bigint }>
+    >();
+    expect(m).toEqual<CompiledMessage>([
+      "Name: ",
+      StringArg("name"),
+      ", Age: ",
+      NumberArg("age", {}),
+    ]);
+  });
+});

--- a/packages/core/src/msg/tagged-template.ts
+++ b/packages/core/src/msg/tagged-template.ts
@@ -1,0 +1,67 @@
+import { destringify, type CompiledMessage } from "../msgfmt.ts";
+import { unwrap, wrap, type Message } from "../opaque.ts";
+
+/**
+ * A tagged template function to construct a type-safe message object.
+ *
+ * Note the difference from the `msg` function exported from `@hi18n/core`'s
+ * root module or the `mf1` function from `@hi18n/core/msg`:
+ *
+ * - The `msg`/`mf1` function takes a single string argument
+ *   and parses it as an ICU MessageFormat 1.0 message.
+ * - This `msg` function is a tagged template function that takes
+ *   template strings and embedded expressions. The string parts
+ *   are treated as literal strings, so MessageFormat escapes are not interpreted.
+ *   Instead, you can use other helper functions from `@hi18n/core/msg`
+ *   (e.g. `arg`) to construct complex messages.
+ *
+ * @since 0.2.1 (`@hi18n/core`)
+ *
+ * @example
+ *   ```ts
+ *   const catalogEn = new Catalog("en", {
+ *     greeting: msg`Hello, ${arg("name")}!`,
+ *   });
+ *   ```
+ */
+export function msg<const Exprs extends Message<never>[]>(
+  strings: TemplateStringsArray,
+  ...exprs: Exprs
+): Message<
+  Exprs extends Message<infer T>[] ? { [K in keyof T]: T[K] } : never
+> {
+  const parts: CompiledMessage[] = [];
+  for (let i = 0; i < strings.length; i++) {
+    pushPart(parts, strings[i]!);
+    if (i < exprs.length) {
+      pushPart(parts, unwrap(exprs[i]!));
+    }
+  }
+  const compiledMessage = (
+    parts.length === 0 ? "" : parts.length === 1 ? parts[0] : parts
+  ) as CompiledMessage;
+  return wrap(destringify(compiledMessage));
+}
+
+function pushPart(parts: CompiledMessage[], part: CompiledMessage): void {
+  if (part == null) {
+    return;
+  }
+  if (typeof part === "string") {
+    if (part === "") {
+      return;
+    }
+    const lastPart = parts[parts.length - 1];
+    if (typeof lastPart === "string") {
+      parts[parts.length - 1] = lastPart + part;
+      return;
+    }
+  }
+  if (Array.isArray(part)) {
+    for (const subPart of part) {
+      pushPart(parts, subPart);
+    }
+    return;
+  }
+  parts.push(part);
+}

--- a/packages/core/src/msg/todo.ts
+++ b/packages/core/src/msg/todo.ts
@@ -1,0 +1,13 @@
+import type { Message } from "../opaque.ts";
+
+/**
+ * Can be used to indicate an untranslated state.
+ *
+ * @param message the translated message
+ * @returns the argument itself
+ *
+ * @since 0.2.1 (`@hi18n/core`)
+ */
+export function todo<Args>(message: Message<Args>): Message<Args> {
+  return message;
+}

--- a/packages/core/src/msg/util.ts
+++ b/packages/core/src/msg/util.ts
@@ -1,0 +1,38 @@
+export function validateName(name: string | number): void {
+  if (typeof name === "number") {
+    if (!Number.isInteger(name)) {
+      throw new TypeError(`Not a valid name: non-integer number ${name}`);
+    } else if (name < 0 || (name === 0 && Object.is(name, -0))) {
+      throw new RangeError(`Not a valid name: negative number ${name}`);
+    } else if (name > Number.MAX_SAFE_INTEGER) {
+      throw new RangeError(
+        `Not a valid name: number ${name} exceeds Number.MAX_SAFE_INTEGER`,
+      );
+    }
+  } else if (typeof name === "string") {
+    if (!/^[A-Z_a-z][0-9A-Z_a-z]*$/.test(name)) {
+      throw new RangeError(`Not a valid name: ${JSON.stringify(name)}`);
+    }
+  } else {
+    throw new TypeError(
+      `Not a valid name: neither a number or a string: ${name as string}`,
+    );
+  }
+}
+
+export function coerceStringOrUndefined<S extends string>(
+  value: S | undefined,
+): S | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  return `${value}` as S;
+}
+export function coerceNumberOrUndefined<N extends number>(
+  value: N | undefined,
+): N | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  return +value as N;
+}

--- a/packages/core/src/msgfmt-eval.test.ts
+++ b/packages/core/src/msgfmt-eval.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vitest } from "vitest";
-import type { CompiledMessage } from "./msgfmt.ts";
+import {
+  DateTimeArg,
+  ElementArg,
+  NumberArg,
+  PluralArg,
+  StringArg,
+  type CompiledMessage,
+} from "./msgfmt.ts";
 import { evaluateMessage } from "./msgfmt-eval.ts";
 import type { ErrorHandler } from "./error-handling.ts";
 
@@ -24,20 +31,20 @@ describe("evaluageMessage", () => {
 
   it("evaluates simple interpolation", () => {
     expect(
-      evaluateMessage(["Hello, ", { type: "Var", name: "name" }, "!"], {
+      evaluateMessage(["Hello, ", StringArg("name"), "!"], {
         locale: "en",
         params: { name: "John" },
       }),
     ).toBe("Hello, John!");
     expect(() =>
-      evaluateMessage(["Hello, ", { type: "Var", name: "name" }, "!"], {
+      evaluateMessage(["Hello, ", StringArg("name"), "!"], {
         id: "greeting.named",
         locale: "en",
         params: {},
       }),
     ).toThrow("Missing argument: name");
     expect(() =>
-      evaluateMessage(["Hello, ", { type: "Var", name: "name" }, "!"], {
+      evaluateMessage(["Hello, ", StringArg("name"), "!"], {
         id: "greeting.named",
         locale: "en",
         params: { name: 42 },
@@ -46,14 +53,8 @@ describe("evaluageMessage", () => {
   });
 
   it("evaluates number interpolation", () => {
-    const msg1: CompiledMessage = [
-      { type: "Var", name: "count", argType: "number" },
-      " apples",
-    ];
-    const msg2: CompiledMessage = [
-      { type: "Var", name: "count", argType: "number" },
-      " pommes",
-    ];
+    const msg1: CompiledMessage = [NumberArg("count", {}), " apples"];
+    const msg2: CompiledMessage = [NumberArg("count", {}), " pommes"];
     expect(evaluateMessage(msg1, { locale: "en", params: { count: 42 } })).toBe(
       "42 apples",
     );
@@ -73,12 +74,9 @@ describe("evaluageMessage", () => {
   });
 
   it("evaluates integer styles", () => {
-    const msg1: CompiledMessage = {
-      type: "Var",
-      name: "foo",
-      argType: "number",
-      argStyle: "integer",
-    };
+    const msg1: CompiledMessage = NumberArg("foo", {
+      maximumFractionDigits: 0,
+    });
     expect(evaluateMessage(msg1, { locale: "en", params: { foo: 42 } })).toBe(
       "42",
     );
@@ -88,12 +86,7 @@ describe("evaluageMessage", () => {
   });
 
   it("evaluates percent styles", () => {
-    const msg1: CompiledMessage = {
-      type: "Var",
-      name: "foo",
-      argType: "number",
-      argStyle: "percent",
-    };
+    const msg1: CompiledMessage = NumberArg("foo", { style: "percent" });
     expect(evaluateMessage(msg1, { locale: "en", params: { foo: 0.42 } })).toBe(
       "42%",
     );
@@ -111,14 +104,8 @@ describe("evaluageMessage", () => {
 
     it("evaluates number interpolation", () => {
       const handleError = vitest.fn<ErrorHandler>();
-      const msg1: CompiledMessage = [
-        { type: "Var", name: "count", argType: "number" },
-        " apples",
-      ];
-      const msg2: CompiledMessage = [
-        { type: "Var", name: "count", argType: "number" },
-        " pommes",
-      ];
+      const msg1: CompiledMessage = [NumberArg("count", {}), " apples"];
+      const msg2: CompiledMessage = [NumberArg("count", {}), " pommes"];
       expect(
         evaluateMessage(msg1, {
           locale: "en",
@@ -151,12 +138,9 @@ describe("evaluageMessage", () => {
 
     it("evaluates integer styles", () => {
       const handleError = vitest.fn<ErrorHandler>();
-      const msg1: CompiledMessage = {
-        type: "Var",
-        name: "foo",
-        argType: "number",
-        argStyle: "integer",
-      };
+      const msg1: CompiledMessage = NumberArg("foo", {
+        maximumFractionDigits: 0,
+      });
       expect(
         evaluateMessage(msg1, {
           locale: "en",
@@ -183,11 +167,7 @@ describe("evaluageMessage", () => {
     const date = new Date(Date.UTC(2006, 0, 2, 22, 4, 5, 999));
 
     {
-      const msg: CompiledMessage = {
-        type: "Var",
-        name: "foo",
-        argType: "date",
-      };
+      const msg: CompiledMessage = DateTimeArg("foo", { dateStyle: "medium" });
       expect(
         evaluateMessage(msg, {
           locale: "en",
@@ -197,12 +177,7 @@ describe("evaluageMessage", () => {
       ).toBe("Jan 2, 2006");
     }
     {
-      const msg: CompiledMessage = {
-        type: "Var",
-        name: "foo",
-        argType: "date",
-        argStyle: "short",
-      };
+      const msg: CompiledMessage = DateTimeArg("foo", { dateStyle: "short" });
       expect(
         evaluateMessage(msg, {
           locale: "en",
@@ -212,12 +187,7 @@ describe("evaluageMessage", () => {
       ).toBe("1/2/06");
     }
     {
-      const msg: CompiledMessage = {
-        type: "Var",
-        name: "foo",
-        argType: "date",
-        argStyle: "medium",
-      };
+      const msg: CompiledMessage = DateTimeArg("foo", { dateStyle: "medium" });
       expect(
         evaluateMessage(msg, {
           locale: "en",
@@ -227,12 +197,7 @@ describe("evaluageMessage", () => {
       ).toBe("Jan 2, 2006");
     }
     {
-      const msg: CompiledMessage = {
-        type: "Var",
-        name: "foo",
-        argType: "date",
-        argStyle: "long",
-      };
+      const msg: CompiledMessage = DateTimeArg("foo", { dateStyle: "long" });
       expect(
         evaluateMessage(msg, {
           locale: "en",
@@ -242,12 +207,7 @@ describe("evaluageMessage", () => {
       ).toBe("January 2, 2006");
     }
     {
-      const msg: CompiledMessage = {
-        type: "Var",
-        name: "foo",
-        argType: "date",
-        argStyle: "full",
-      };
+      const msg: CompiledMessage = DateTimeArg("foo", { dateStyle: "full" });
       expect(
         evaluateMessage(msg, {
           locale: "en",
@@ -258,11 +218,7 @@ describe("evaluageMessage", () => {
     }
 
     {
-      const msg: CompiledMessage = {
-        type: "Var",
-        name: "foo",
-        argType: "time",
-      };
+      const msg: CompiledMessage = DateTimeArg("foo", { timeStyle: "medium" });
       expect(
         evaluateMessage(msg, {
           locale: "en",
@@ -272,12 +228,7 @@ describe("evaluageMessage", () => {
       ).toBe("3:04:05 PM");
     }
     {
-      const msg: CompiledMessage = {
-        type: "Var",
-        name: "foo",
-        argType: "time",
-        argStyle: "short",
-      };
+      const msg: CompiledMessage = DateTimeArg("foo", { timeStyle: "short" });
       expect(
         evaluateMessage(msg, {
           locale: "en",
@@ -287,12 +238,7 @@ describe("evaluageMessage", () => {
       ).toBe("3:04 PM");
     }
     {
-      const msg: CompiledMessage = {
-        type: "Var",
-        name: "foo",
-        argType: "time",
-        argStyle: "medium",
-      };
+      const msg: CompiledMessage = DateTimeArg("foo", { timeStyle: "medium" });
       expect(
         evaluateMessage(msg, {
           locale: "en",
@@ -302,12 +248,7 @@ describe("evaluageMessage", () => {
       ).toBe("3:04:05 PM");
     }
     {
-      const msg: CompiledMessage = {
-        type: "Var",
-        name: "foo",
-        argType: "time",
-        argStyle: "long",
-      };
+      const msg: CompiledMessage = DateTimeArg("foo", { timeStyle: "long" });
       expect(
         evaluateMessage(msg, {
           locale: "en",
@@ -324,12 +265,7 @@ describe("evaluageMessage", () => {
       );
     }
     {
-      const msg: CompiledMessage = {
-        type: "Var",
-        name: "foo",
-        argType: "time",
-        argStyle: "full",
-      };
+      const msg: CompiledMessage = DateTimeArg("foo", { timeStyle: "full" });
       expect(
         evaluateMessage(msg, {
           locale: "en",
@@ -357,11 +293,7 @@ describe("evaluageMessage", () => {
     }
 
     {
-      const msg: CompiledMessage = {
-        type: "Var",
-        name: "foo",
-        argType: "date",
-      };
+      const msg: CompiledMessage = DateTimeArg("foo", { dateStyle: "medium" });
       expect(
         evaluateMessage(msg, {
           locale: "en",
@@ -373,38 +305,30 @@ describe("evaluageMessage", () => {
   });
 
   it("evaluates plural interpolation", () => {
-    const msg1: CompiledMessage = {
-      type: "Plural",
-      name: "count",
-      branches: [
+    const msg1: CompiledMessage = PluralArg(
+      "count",
+      [
         {
           selector: "one",
-          message: ["There is ", { type: "Number" }, " apple."],
-        },
-        {
-          selector: "other",
-          message: ["There are ", { type: "Number" }, " apples."],
+          message: ["There is ", NumberArg("count", {}), " apple."],
         },
       ],
-    };
-    const msg2: CompiledMessage = {
-      type: "Plural",
-      name: "count",
-      branches: [
+      ["There are ", NumberArg("count", {}), " apples."],
+    );
+    const msg2: CompiledMessage = PluralArg(
+      "count",
+      [
         {
           selector: "one",
-          message: ["Там ", { type: "Number" }, " яблоко."],
+          message: ["Там ", NumberArg("count", {}), " яблоко."],
         },
         {
           selector: "few",
-          message: ["Там ", { type: "Number" }, " яблока."],
-        },
-        {
-          selector: "other",
-          message: ["Там ", { type: "Number" }, " яблок."],
+          message: ["Там ", NumberArg("count", {}), " яблока."],
         },
       ],
-    };
+      ["Там ", NumberArg("count", {}), " яблок."],
+    );
     expect(evaluateMessage(msg1, { locale: "en", params: { count: 0 } })).toBe(
       "There are 0 apples.",
     );
@@ -447,41 +371,37 @@ describe("evaluageMessage", () => {
   });
 
   it("evaluates plural interpolation with offsets", () => {
-    const msg1: CompiledMessage = {
-      type: "Plural",
-      name: "count",
-      offset: 1,
-      branches: [
+    const msg1: CompiledMessage = PluralArg(
+      "count",
+      [
         {
           selector: 0,
           message: ["Connected to no one"],
         },
         {
           selector: 1,
-          message: ["Connected to ", { type: "Var", name: "name" }],
+          message: ["Connected to ", StringArg("name")],
         },
         {
           selector: "one",
           message: [
             "Connected to ",
-            { type: "Var", name: "name" },
+            StringArg("name"),
             " and ",
-            { type: "Number" },
+            NumberArg("count", {}, { subtract: 1 }),
             " other",
           ],
         },
-        {
-          selector: "other",
-          message: [
-            "Connected to ",
-            { type: "Var", name: "name" },
-            " and ",
-            { type: "Number" },
-            " others",
-          ],
-        },
       ],
-    };
+      [
+        "Connected to ",
+        StringArg("name"),
+        " and ",
+        NumberArg("count", {}, { subtract: 1 }),
+        " others",
+      ],
+      { subtract: 1 },
+    );
     expect(
       evaluateMessage(msg1, { locale: "en", params: { count: 0, name: "" } }),
     ).toBe("Connected to no one");
@@ -518,38 +438,30 @@ describe("evaluageMessage", () => {
 
     it("evaluates plural interpolation", () => {
       const handleError = vitest.fn<ErrorHandler>();
-      const msg1: CompiledMessage = {
-        type: "Plural",
-        name: "count",
-        branches: [
+      const msg1: CompiledMessage = PluralArg(
+        "count",
+        [
           {
             selector: "one",
-            message: ["There is ", { type: "Number" }, " apple."],
-          },
-          {
-            selector: "other",
-            message: ["There are ", { type: "Number" }, " apples."],
+            message: ["There is ", NumberArg("count", {}), " apple."],
           },
         ],
-      };
-      const msg2: CompiledMessage = {
-        type: "Plural",
-        name: "count",
-        branches: [
+        ["There are ", NumberArg("count", {}), " apples."],
+      );
+      const msg2: CompiledMessage = PluralArg(
+        "count",
+        [
           {
             selector: "one",
-            message: ["Там ", { type: "Number" }, " яблоко."],
+            message: ["Там ", NumberArg("count", {}), " яблоко."],
           },
           {
             selector: "few",
-            message: ["Там ", { type: "Number" }, " яблока."],
-          },
-          {
-            selector: "other",
-            message: ["Там ", { type: "Number" }, " яблок."],
+            message: ["Там ", NumberArg("count", {}), " яблока."],
           },
         ],
-      };
+        ["Там ", NumberArg("count", {}), " яблок."],
+      );
       expect(
         evaluateMessage(msg1, {
           locale: "en",
@@ -645,41 +557,37 @@ describe("evaluageMessage", () => {
 
     it("evaluates plural interpolation with offsets", () => {
       const handleError = vitest.fn<ErrorHandler>();
-      const msg1: CompiledMessage = {
-        type: "Plural",
-        name: "count",
-        offset: 1,
-        branches: [
+      const msg1: CompiledMessage = PluralArg(
+        "count",
+        [
           {
             selector: 0,
             message: ["Connected to no one"],
           },
           {
             selector: 1,
-            message: ["Connected to ", { type: "Var", name: "name" }],
+            message: ["Connected to ", StringArg("name")],
           },
           {
             selector: "one",
             message: [
               "Connected to ",
-              { type: "Var", name: "name" },
+              StringArg("name"),
               " and ",
-              { type: "Number" },
+              NumberArg("count", {}, { subtract: 1 }),
               " other",
             ],
           },
-          {
-            selector: "other",
-            message: [
-              "Connected to ",
-              { type: "Var", name: "name" },
-              " and ",
-              { type: "Number" },
-              " others",
-            ],
-          },
         ],
-      };
+        [
+          "Connected to ",
+          StringArg("name"),
+          " and ",
+          NumberArg("count", {}, { subtract: 1 }),
+          " others",
+        ],
+        { subtract: 1 },
+      );
       expect(
         evaluateMessage(msg1, {
           locale: "en",
@@ -762,70 +670,30 @@ describe("evaluageMessage", () => {
 
     const msg2: CompiledMessage = [
       "You have ",
-      {
-        type: "Plural",
-        name: "newMessages",
-        branches: [
+      PluralArg(
+        "newMessages",
+        [
           {
             selector: "one",
-            message: [
-              {
-                type: "Var",
-                name: "newMessages",
-                argType: "number",
-              },
-              " new message",
-            ],
-          },
-          {
-            selector: "other",
-            message: [
-              {
-                type: "Var",
-                name: "newMessages",
-                argType: "number",
-              },
-              " new messages",
-            ],
+            message: [NumberArg("newMessages", {}), " new message"],
           },
         ],
-      },
+        [NumberArg("newMessages", {}), " new messages"],
+      ),
       ". ",
-      {
-        type: "Element",
-        name: 0,
-        message: [
-          "See all the ",
-          {
-            type: "Plural",
-            name: "messages",
-            branches: [
-              {
-                selector: "one",
-                message: [
-                  {
-                    type: "Var",
-                    name: "messages",
-                    argType: "number",
-                  },
-                  " message",
-                ],
-              },
-              {
-                selector: "other",
-                message: [
-                  {
-                    type: "Var",
-                    name: "messages",
-                    argType: "number",
-                  },
-                  " messages",
-                ],
-              },
-            ],
-          },
-        ],
-      },
+      ElementArg(0, [
+        "See all the ",
+        PluralArg(
+          "messages",
+          [
+            {
+              selector: "one",
+              message: [NumberArg("messages", {}), " message"],
+            },
+          ],
+          [NumberArg("messages", {}), " messages"],
+        ),
+      ]),
       ".",
     ];
     expect(

--- a/packages/core/src/msgfmt-eval.ts
+++ b/packages/core/src/msgfmt-eval.ts
@@ -63,8 +63,8 @@ export function evaluateMessage<T = string>(
         }
         const offsetValue =
           typeof value === "bigint"
-            ? value - BigInt(msg.subtract ?? 0)
-            : value - (msg.subtract ?? 0);
+            ? value - BigInt(msg.subtract)
+            : value - msg.subtract;
         // TODO: Remove this fallback because it is nowadays widely supported.
         if (typeof Intl === "undefined" || !Intl.NumberFormat) {
           const fallback = numberFormatFallback(offsetValue, msg.argStyle);
@@ -117,9 +117,9 @@ export function evaluateMessage<T = string>(
       });
     }
     if (typeof value === "number") {
-      relativeValue = value - (msg.subtract ?? 0);
+      relativeValue = value - msg.subtract;
     } else if (typeof value === "bigint") {
-      relativeValue = value - BigInt(msg.subtract ?? 0);
+      relativeValue = value - BigInt(msg.subtract);
     } else {
       throw new ArgumentTypeError({
         argName: msg.name,

--- a/packages/core/src/msgfmt-parser-types.test.ts
+++ b/packages/core/src/msgfmt-parser-types.test.ts
@@ -1,12 +1,8 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 
 import { describe, it } from "vitest";
-import type { Message } from "./index.ts";
-import type {
-  ComponentPlaceholder,
-  InferredMessageType,
-  ParseError,
-} from "./msgfmt-parser-types.ts";
+import type { ComponentPlaceholder, Message } from "./opaque.ts";
+import type { InferredMessageType, ParseError } from "./msgfmt-parser-types.ts";
 
 describe("InferredMessageType", () => {
   it("infers no arguments", () => {

--- a/packages/core/src/msgfmt-parser-types.ts
+++ b/packages/core/src/msgfmt-parser-types.ts
@@ -3,10 +3,7 @@
 // The parser algorithm is written to vastly match what is implemented in ./msgfmt-parser.ts, but with a few differences.
 
 import type { Message } from "./index.ts";
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-declare const componentPlaceholderSymbol: unique symbol;
-export type ComponentPlaceholder = typeof componentPlaceholderSymbol;
+import type { ComponentPlaceholder } from "./opaque.ts";
 
 export type ParseResult<
   Accum,

--- a/packages/core/src/msgfmt.ts
+++ b/packages/core/src/msgfmt.ts
@@ -1,4 +1,9 @@
+import type { ParseError } from "./errors.ts";
+
 export type CompiledMessage =
+  /* deferred parse error for backward compatibility */
+  /* TODO: remove this in future major version */
+  | DeferredParseError
   /* plain message. Quotations such as "It''s awsesome" are already unescaped. */
   | string
   /* concatenation */
@@ -7,81 +12,82 @@ export type CompiledMessage =
   | VarArg
   /* plural form selection */
   | PluralArg
-  /* # */
-  | NumberSign
   /* component interpolation (<0>foo</0>) */
   | ElementArg;
 
-export type VarArg =
-  | StringArg
-  | NumberArg
-  | DateArg
-  | TimeArg
-  | SpelloutArg
-  | OrdinalArg
-  | DurationArg;
+export type VarArg = StringArg | NumberArg | DateTimeArg;
 
 export type StringArg = {
   type: "Var";
   name: string | number;
-  argType?: undefined;
+  argType: "string";
 };
+export function StringArg(name: string | number): StringArg {
+  return { type: "Var", name, argType: "string" };
+}
 
 export type NumberArg = {
   type: "Var";
   name: string | number;
   argType: "number";
-  // TODO: skeleton
-  argStyle?: "integer" | "currency" | "percent" | undefined;
+  argStyle: Intl.NumberFormatOptions;
+  subtract: number;
 };
+export type NumberArgInternalOptions = {
+  subtract?: number;
+};
+export function NumberArg(
+  name: string | number,
+  argStyle: Intl.NumberFormatOptions,
+  options: NumberArgInternalOptions = {},
+): NumberArg {
+  const { subtract = 0 } = options;
+  return { type: "Var", name, argType: "number", argStyle, subtract };
+}
 
-export type DateArg = {
+export type DateTimeArg = {
   type: "Var";
   name: string | number;
-  argType: "date";
-  argStyle?: "short" | "medium" | "long" | "full" | Intl.DateTimeFormatOptions;
+  argType: "datetime";
+  argStyle: Intl.DateTimeFormatOptions;
 };
-
-export type TimeArg = {
-  type: "Var";
-  name: string | number;
-  argType: "time";
-  argStyle?: "short" | "medium" | "long" | "full";
-};
-
-export type SpelloutArg = {
-  type: "Var";
-  name: string | number;
-  argType: "spellout";
-};
-
-export type OrdinalArg = {
-  type: "Var";
-  name: string | number;
-  argType: "ordinal";
-};
-
-export type DurationArg = {
-  type: "Var";
-  name: string | number;
-  argType: "duration";
-};
+export function DateTimeArg(
+  name: string | number,
+  argStyle: Intl.DateTimeFormatOptions,
+): DateTimeArg {
+  return { type: "Var", name, argType: "datetime", argStyle };
+}
 
 export type PluralArg = {
   type: "Plural";
   name: string | number;
-  offset?: number | undefined;
+  subtract: number;
   branches: PluralBranch[];
+  fallback: CompiledMessage;
 };
+export type PluralArgInternalOptions = {
+  subtract?: number;
+};
+export function PluralArg(
+  name: string | number,
+  branches: PluralBranch[],
+  fallback: CompiledMessage,
+  options: PluralArgInternalOptions = {},
+): PluralArg {
+  const { subtract = 0 } = options;
+  return { type: "Plural", name, subtract, branches, fallback };
+}
 
 export type PluralBranch = {
   selector: number | string;
   message: CompiledMessage;
 };
-
-export type NumberSign = {
-  type: "Number";
-};
+export function PluralBranch(
+  selector: number | string,
+  message: CompiledMessage,
+): PluralBranch {
+  return { selector, message };
+}
 
 export type ArgType = NonNullable<VarArg["argType"]>;
 
@@ -90,3 +96,38 @@ export type ElementArg = {
   name: string | number;
   message?: CompiledMessage | undefined;
 };
+export function ElementArg(
+  name: string | number,
+  message?: CompiledMessage,
+): ElementArg {
+  return { type: "Element", name, message };
+}
+
+export type DeferredParseError = {
+  type: "DeferredParseError";
+  sourceText: string;
+  error: ParseError;
+};
+export function DeferredParseError(
+  sourceText: string,
+  error: ParseError,
+): DeferredParseError {
+  return { type: "DeferredParseError", sourceText, error };
+}
+
+// TODO: remove this in future major version
+/**
+ * In @hi18n/core v0.2.x, the Catalog constructor rejects bare string messages
+ * to prevent accidental usage of unparsed messages.
+ *
+ * This function is here to allow use of msg(), mf1(), or msg`` messages
+ * even when the message is a plain string.
+ * @param msg
+ * @returns
+ */
+export function destringify(msg: CompiledMessage): CompiledMessage {
+  if (typeof msg === "string") {
+    return [msg];
+  }
+  return msg;
+}

--- a/packages/core/src/opaque.ts
+++ b/packages/core/src/opaque.ts
@@ -1,0 +1,28 @@
+/* eslint-disable @typescript-eslint/no-empty-object-type */
+
+import type { CompiledMessage } from "./msgfmt.ts";
+
+declare const messageBrandSymbol: unique symbol;
+
+/**
+ * An opaque type that represents translation messages.
+ *
+ * @param Args parameters required by this message
+ *
+ * @since 0.1.0 (`@hi18n/core`)
+ */
+export type Message<Args = {}> = {
+  [messageBrandSymbol]: (args: Args) => void;
+};
+
+export function wrap<Args>(msg: CompiledMessage): Message<Args> {
+  return msg as unknown as Message<Args>;
+}
+
+export function unwrap<Args>(msg: Message<Args>): CompiledMessage {
+  return msg as unknown as CompiledMessage;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+declare const componentPlaceholderSymbol: unique symbol;
+export type ComponentPlaceholder = typeof componentPlaceholderSymbol;

--- a/packages/react/src/index.test.tsx
+++ b/packages/react/src/index.test.tsx
@@ -17,7 +17,6 @@ import {
 } from "@hi18n/core";
 import { LocaleProvider, Translate, useI18n, useLocales } from "./index.tsx";
 import type { ComponentPlaceholder } from "@hi18n/core";
-import { LocaleContext } from "@hi18n/react-context";
 
 const prettyFormat = prettyFormat_ as {
   default: unknown;
@@ -153,37 +152,6 @@ describe("useLocales", () => {
     act(() => increment());
     expect(screen.queryByText("count = 2")).toBeInTheDocument();
     expect(localeObjects.size).toBe(1);
-  });
-
-  it("is future-proof for when an array of strings is passed instead", () => {
-    const LocaleLength: React.FC = () => {
-      const locales = useLocales();
-      return <>It has {locales.length} locales in context.</>;
-    };
-    {
-      render(
-        <LocaleContext.Provider
-          value={["en", "ja", "zh-CN"] as string | string[] as string}
-        >
-          <LocaleLength />
-        </LocaleContext.Provider>,
-      );
-      expect(
-        screen.queryByText("It has 3 locales in context."),
-      ).toBeInTheDocument();
-      cleanup();
-    }
-    {
-      render(
-        <LocaleContext.Provider value={[] as string | string[] as string}>
-          <LocaleLength />
-        </LocaleContext.Provider>,
-      );
-      expect(
-        screen.queryByText("It has 0 locales in context."),
-      ).toBeInTheDocument();
-      cleanup();
-    }
   });
 });
 


### PR DESCRIPTION
## Why

We are migrating away from ICU MessageFormat 1.0 for several reasons:

- There is MessageFormat 2.0 under standardization. Though I feel MF2 is too complex, several design decisions are worth incorporating into this library, and we may also support a subset of MF2.
- The current message builder parses the message syntax through TypeScript type-level metaprogramming. I suspect it's putting a heavy burden on the typechecker, so I want to provide a more lightweight alternative.
- The compiled messages' format is not necessarily stable or compatible with other tools. The only requirement is that your JavaScript code works as long as the definitions and uses of the messages depend on the same `@hi18n/core` version.
- At first, I hoped the MF1.0 format would contribute to small bundle sizes, but now I recognize that most messages are simple strings.

## What

Introduce an alternative set of utilities to build type-safe messages. These are exported from `@hi18n/core/msg`. This is effectively a JavaScript DSL.

```ts
import { Catalog, msg } from "@hi18n/core";
import { mf1, arg } from "@hi18n/core/msg";

const catalogEn = new Catalog("en", {
  // Status quo
  "greeting/classic": msg("Hello, {name}!"),
  // New DSL
  "greeting/jsdsl": msg`Hello, ${arg("name")}!`,
});
```

Internally, we also do the actual parsing in `msg(...)` function, rather than parsing them on-the-fly when the translation is actually used. However, for backward compatibility, parse errors are thrown on use.

Also, to make things clear, we rename the existing `msg(...)` function to `mf1(...)` and export it from `@hi18n/core/msg` too. The original functions are kept for compatibility.

Please note that this PR does not imply that we will immediately remove MF1.0 support. We will just support two formats in parallel. However, feature parity is not guaranteed in MF1.0 format.

This PR is a big update, but is still marked as a feature change as it will not introduce incompatibilities. Additionally, as the library is still on v0, we use a semver patch bump rather than minor bumps.

Important predecessors to this PR:

- https://github.com/wantedly/hi18n/pull/243
- https://github.com/wantedly/hi18n/pull/237

What comes next:

- Support new constructs in the ESLint plugin / CLI
- Add new ESLint rules to migrate between two formats
- Planned breaking changes
  - Remove the old `msg` overloaded function
- Unban string literals as messages, but this time interpret them as plaintext (rather than in MF1.0)