### PR TITLE
fix(core): check template escape correctness

### DIFF
--- a/.changeset/wild-towns-warn.md
+++ b/.changeset/wild-towns-warn.md
@@ -1,0 +1,5 @@
+---
+"@hi18n/core": patch
+---
+
+fix(core): check template escape correctness

--- a/packages/core/src/msg/tagged-template.test.ts
+++ b/packages/core/src/msg/tagged-template.test.ts
@@ -48,4 +48,10 @@ describe("msg tag", () => {
       NumberArg("age", {}),
     ]);
   });
+
+  it("throws SyntaxError when there is an invalid JS escape sequence", () => {
+    expect(() => {
+      const _msg = msg`\u`;
+    }).toThrow(SyntaxError);
+  });
 });

--- a/packages/core/src/msg/tagged-template.ts
+++ b/packages/core/src/msg/tagged-template.ts
@@ -32,7 +32,11 @@ export function msg<const Exprs extends Message<never>[]>(
 > {
   const parts: CompiledMessage[] = [];
   for (let i = 0; i < strings.length; i++) {
-    pushPart(parts, strings[i]!);
+    const quasi = strings[i];
+    if (quasi == null) {
+      throw new SyntaxError("Invalid escape sequence in template string");
+    }
+    pushPart(parts, quasi);
     if (i < exprs.length) {
       pushPart(parts, unwrap(exprs[i]!));
     }


### PR DESCRIPTION
## Why

JS tagged templates allow invalid escape sequences in the text part.

```js
// Error
const x = `\u`;
// Allowed, equivalent to tag(Object.assign([undefined], { raw: ["\\u"] }))
const y = tag`\u`;
```

This feature is useful when one wants to use different escape syntaxes than the default one through `raw`. However, when one simply wants JS escape syntax, it can lead to confusing results.

## What

In the ``msg`...` `` tagged templates, check if there is an invalid escape sequence. If there is one, throw SyntaxError.

This is technically a breaking change, as previously working code may error; however, it should be practically safe to introduce this change because the new utilities are barely used yet, and escapes are rarely introduced in the corresponding arguments.