### PR TITLE
chore(test): configure vitest for monorepo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,6 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
       - run: yarn build
-      - run: yarn test:nobuild
+      - run: yarn test:nobuild --watch=false
       - run: yarn lint:nobuild
       - run: yarn fmt:check

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "yarn build && yarn lint:nobuild",
     "lint:nobuild": "yarn eslint .",
     "test": "yarn build && yarn test:nobuild",
-    "test:nobuild": "yarn workspaces foreach -Ap --exclude root run test --watch=false",
+    "test:nobuild": "yarn vitest",
     "tsc": "yarn build && yarn tsc:nobuild",
     "tsc:nobuild": "yarn workspaces foreach -Ap --exclude root run tsc"
   },
@@ -30,9 +30,11 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
     "globals": "^16.3.0",
+    "jsdom": "^26.1.0",
     "prettier": "^3.6.2",
     "typescript": "^5.9.2",
-    "typescript-eslint": "^8.42.0"
+    "typescript-eslint": "^8.42.0",
+    "vitest": "^3.2.4"
   },
   "resolutions": {
     "pretty-format/react-is": "^19.0.0",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig, type ViteUserConfig } from "vitest/config";
+
+export { config as default };
+const config: ViteUserConfig = defineConfig({
+  test: {
+    projects: ["packages/*"],
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4996,9 +4996,11 @@ __metadata:
     eslint-plugin-react: "npm:^7.37.5"
     eslint-plugin-react-hooks: "npm:^5.2.0"
     globals: "npm:^16.3.0"
+    jsdom: "npm:^26.1.0"
     prettier: "npm:^3.6.2"
     typescript: "npm:^5.9.2"
     typescript-eslint: "npm:^8.42.0"
+    vitest: "npm:^3.2.4"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Why

Vitest has [built-in support for monorepo](https://vitest.dev/guide/projects). It is helpful for several reasons:

- The VS Code extension is properly configured as a result.
- It reduces `yarn workspaces foreach`, allowing us to leverage parallelism more.
- It will reduce configuration in th efuture husky + lint-staged adaptation.

## What

Configure vitest for monorepo.