### PR TITLE
chore(build): fix workspace build

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   ],
   "type": "module",
   "scripts": {
-    "build": "yarn workspaces foreach -Apt run build",
+    "build": "yarn workspaces foreach -Ap --topological-dev run build",
     "clean": "yarn workspaces foreach -Ap run clean",
     "fmt": "prettier -w .",
     "fmt:check": "prettier -c .",


### PR DESCRIPTION
## Why

Since https://github.com/wantedly/hi18n/pull/242 the workspace-level `yarn build` was broken because [`-t` does not track peerDependencies or devDependencies](https://yarnpkg.com/cli/workspaces/foreach).

## What

Use `--topological-dev` to get a desired ordering.