### PR TITLE
chore(monorepo): ensure fmt/lint/test work both workspace-wide and per-package

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -47,6 +47,9 @@
     "build:cjs": "tsc -p tsconfig.build-cjs.json",
     "build:esm": "tsc -p tsconfig.build.json",
     "clean": "rimraf dist cjs/dist",
+    "fmt": "yarn workspace root prettier -w ./packages/cli",
+    "fmt:check": "yarn workspace root prettier -c ./packages/cli",
+    "lint": "yarn workspace root eslint ./packages/cli",
     "prepack": "$npm_execpath run clean && $npm_execpath run build",
     "test": "vitest",
     "tsc": "tsc"

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,0 +1,4 @@
+import { defineConfig, type ViteUserConfig } from "vitest/config";
+
+export { config as default };
+const config: ViteUserConfig = defineConfig({});

--- a/packages/connector-i18n-js/package.json
+++ b/packages/connector-i18n-js/package.json
@@ -44,6 +44,9 @@
     "build:cjs": "tsc -p tsconfig.build-cjs.json",
     "build:esm": "tsc -p tsconfig.build.json",
     "clean": "rimraf dist cjs/dist",
+    "fmt": "yarn workspace root prettier -w ./packages/connector-i18n-js",
+    "fmt:check": "yarn workspace root prettier -c ./packages/connector-i18n-js",
+    "lint": "yarn workspace root eslint ./packages/connector-i18n-js",
     "prepack": "$npm_execpath run clean && $npm_execpath run build",
     "test": "vitest",
     "tsc": "tsc"

--- a/packages/connector-i18n-js/vitest.config.ts
+++ b/packages/connector-i18n-js/vitest.config.ts
@@ -1,0 +1,4 @@
+import { defineConfig, type ViteUserConfig } from "vitest/config";
+
+export { config as default };
+const config: ViteUserConfig = defineConfig({});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -51,6 +51,9 @@
     "build:cjs": "tsc -p tsconfig.build-cjs.json",
     "build:esm": "tsc -p tsconfig.build.json",
     "clean": "rimraf dist cjs/dist",
+    "fmt": "yarn workspace root prettier -w ./packages/core",
+    "fmt:check": "yarn workspace root prettier -c ./packages/core",
+    "lint": "yarn workspace root eslint ./packages/core",
     "prepack": "$npm_execpath run clean && $npm_execpath run build",
     "test": "vitest",
     "tsc": "tsc"

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,4 @@
+import { defineConfig, type ViteUserConfig } from "vitest/config";
+
+export { config as default };
+const config: ViteUserConfig = defineConfig({});

--- a/packages/dev-utils/package.json
+++ b/packages/dev-utils/package.json
@@ -44,6 +44,9 @@
     "build:cjs": "tsc -p tsconfig.build-cjs.json",
     "build:esm": "tsc -p tsconfig.build.json",
     "clean": "rimraf dist cjs/dist",
+    "fmt": "yarn workspace root prettier -w ./packages/dev-utils",
+    "fmt:check": "yarn workspace root prettier -c ./packages/dev-utils",
+    "lint": "yarn workspace root eslint ./packages/dev-utils",
     "prepack": "$npm_execpath run clean && $npm_execpath run build",
     "test": "vitest",
     "tsc": "tsc"

--- a/packages/dev-utils/vitest.config.ts
+++ b/packages/dev-utils/vitest.config.ts
@@ -1,0 +1,4 @@
+import { defineConfig, type ViteUserConfig } from "vitest/config";
+
+export { config as default };
+const config: ViteUserConfig = defineConfig({});

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -51,6 +51,9 @@
     "build:cjs": "tsc -p tsconfig.build-cjs.json",
     "build:esm": "tsc -p tsconfig.build.json",
     "clean": "rimraf dist cjs/dist",
+    "fmt": "yarn workspace root prettier -w ./packages/eslint-plugin",
+    "fmt:check": "yarn workspace root prettier -c ./packages/eslint-plugin",
+    "lint": "yarn workspace root eslint ./packages/eslint-plugin",
     "prepack": "$npm_execpath run clean && $npm_execpath run build",
     "test": "vitest",
     "tsc": "tsc"

--- a/packages/eslint-plugin/vitest.config.ts
+++ b/packages/eslint-plugin/vitest.config.ts
@@ -1,0 +1,4 @@
+import { defineConfig, type ViteUserConfig } from "vitest/config";
+
+export { config as default };
+const config: ViteUserConfig = defineConfig({});

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -47,6 +47,9 @@
     "build:cjs": "tsc -p tsconfig.build-cjs.json",
     "build:esm": "tsc -p tsconfig.build.json",
     "clean": "rimraf dist cjs/dist",
+    "fmt": "yarn workspace root prettier -w ./packages/react",
+    "fmt:check": "yarn workspace root prettier -c ./packages/react",
+    "lint": "yarn workspace root eslint ./packages/react",
     "prepack": "$npm_execpath run clean && $npm_execpath run build",
     "test": "vitest",
     "tsc": "tsc"

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -1,0 +1,4 @@
+import { defineConfig, type ViteUserConfig } from "vitest/config";
+
+export { config as default };
+const config: ViteUserConfig = defineConfig({});

--- a/packages/tools-core/package.json
+++ b/packages/tools-core/package.json
@@ -43,6 +43,9 @@
     "build:cjs": "tsc -p tsconfig.build-cjs.json",
     "build:esm": "tsc -p tsconfig.build.json",
     "clean": "rimraf dist cjs/dist",
+    "fmt": "yarn workspace root prettier -w ./packages/tools-core",
+    "fmt:check": "yarn workspace root prettier -c ./packages/tools-core",
+    "lint": "yarn workspace root eslint ./packages/tools-core",
     "prepack": "$npm_execpath run clean && $npm_execpath run build",
     "test": "vitest",
     "tsc": "tsc"

--- a/packages/tools-core/vitest.config.ts
+++ b/packages/tools-core/vitest.config.ts
@@ -1,0 +1,4 @@
+import { defineConfig, type ViteUserConfig } from "vitest/config";
+
+export { config as default };
+const config: ViteUserConfig = defineConfig({});

--- a/packages/ts-plugin/package.json
+++ b/packages/ts-plugin/package.json
@@ -34,6 +34,9 @@
     "build:cjs": "tsc -p tsconfig.build-cjs.json",
     "build:esm": "tsc -p tsconfig.build.json",
     "clean": "rimraf dist cjs/dist",
+    "fmt": "yarn workspace root prettier -w ./packages/ts-plugin",
+    "fmt:check": "yarn workspace root prettier -c ./packages/ts-plugin",
+    "lint": "yarn workspace root eslint ./packages/ts-plugin",
     "prepack": "$npm_execpath run clean && $npm_execpath run build",
     "tsc": "tsc"
   },


### PR DESCRIPTION
## Why

For a better dev experience

## What

Ensure that `yarn fmt`, `yarn fmt:check`, `yarn lint`, and `yarn test` commands all work both workspace-wide and package-wise.