### PR TITLE
chore(monorepo): use references in tsconfig

### DIFF
--- a/.changeset/floppy-beds-smash.md
+++ b/.changeset/floppy-beds-smash.md
@@ -1,0 +1,12 @@
+---
+"@hi18n/connector-i18n-js": patch
+"@hi18n/eslint-plugin": patch
+"@hi18n/tools-core": patch
+"@hi18n/dev-utils": patch
+"@hi18n/ts-plugin": patch
+"@hi18n/react": patch
+"@hi18n/core": patch
+"@hi18n/cli": patch
+---
+
+chore(monorepo): use references in tsconfig

--- a/package.json
+++ b/package.json
@@ -7,16 +7,15 @@
   ],
   "type": "module",
   "scripts": {
-    "build": "yarn workspaces foreach -Ap --topological-dev run build",
-    "clean": "yarn workspaces foreach -Ap run clean",
+    "build": "tsc --build",
+    "clean": "yarn workspaces foreach -Ap run clean && rm -f '*.tsbuildinfo'",
     "fmt": "prettier -w .",
     "fmt:check": "prettier -c .",
     "lint": "yarn build && yarn lint:nobuild",
     "lint:nobuild": "yarn eslint .",
     "test": "yarn build && yarn test:nobuild",
     "test:nobuild": "yarn vitest",
-    "tsc": "yarn build && yarn tsc:nobuild",
-    "tsc:nobuild": "yarn workspaces foreach -Ap --exclude root run tsc"
+    "tsc": "tsc --build"
   },
   "devDependencies": {
     "@changesets/cli": "patch:@changesets/cli@npm%3A2.29.6#~/.yarn/patches/@changesets-cli-npm-2.29.6-ac8361deb8.patch",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,7 +30,7 @@
     "dist/**/*",
     "cjs/**/*",
     "src/**/*",
-    "!src/**/*.test.ts",
+    "!**/*.test.*",
     "!src/__fixtures__/**/*"
   ],
   "bin": {
@@ -43,16 +43,14 @@
     "default": "./dist/index.js"
   },
   "scripts": {
-    "build": "$npm_execpath run build:esm && $npm_execpath run build:cjs",
-    "build:cjs": "tsc -p tsconfig.build-cjs.json",
-    "build:esm": "tsc -p tsconfig.build.json",
-    "clean": "rimraf dist cjs/dist",
+    "build": "tsc --build",
+    "clean": "rimraf dist cjs/dist '*.tsbuildinfo'",
     "fmt": "yarn workspace root prettier -w ./packages/cli",
     "fmt:check": "yarn workspace root prettier -c ./packages/cli",
     "lint": "yarn workspace root eslint ./packages/cli",
     "prepack": "$npm_execpath run clean && $npm_execpath run build",
     "test": "vitest",
-    "tsc": "tsc"
+    "tsc": "tsc --build"
   },
   "dependencies": {
     "@hi18n/eslint-plugin": "^0.2.3",

--- a/packages/cli/tsconfig.build-cjs.json
+++ b/packages/cli/tsconfig.build-cjs.json
@@ -2,7 +2,17 @@
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "module": "commonjs",
+    "moduleResolution": "node10",
     "outDir": "./cjs/dist",
+    "tsBuildInfoFile": "./tsconfig.build-cjs.tsbuildinfo",
     "verbatimModuleSyntax": false
-  }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.*", "src/__fixtures__/**/*"],
+  "references": [
+    { "path": "../eslint-plugin/tsconfig.build-cjs.json" },
+    { "path": "../tools-core/tsconfig.build-cjs.json" },
+    { "path": "../core/tsconfig.build-cjs.json" },
+    { "path": "../dev-utils/tsconfig.build-cjs.json" }
+  ]
 }

--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -1,13 +1,15 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "noEmit": false,
     "rootDir": "./src",
-    "outDir": "./dist",
-    "declaration": true,
-    "sourceMap": true,
-    "declarationMap": true
+    "outDir": "./dist"
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["src/__fixtures__/**/*", "**/*.test.ts"]
+  "include": ["src/**/*"],
+  "exclude": ["src/__fixtures__/**/*"],
+  "references": [
+    { "path": "../eslint-plugin/tsconfig.build.json" },
+    { "path": "../tools-core/tsconfig.build.json" },
+    { "path": "../core/tsconfig.build.json" },
+    { "path": "../dev-utils/tsconfig.build.json" }
+  ]
 }

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,4 +1,11 @@
 {
-  "extends": "../../tsconfig.json",
-  "exclude": ["dist/**/*", "cjs/dist/**/*", "src/__fixtures__/**/*"]
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "exclude": ["dist/**/*", "cjs/dist/**/*", "src/**/*"],
+  "references": [
+    { "path": "./tsconfig.build.json" },
+    { "path": "./tsconfig.build-cjs.json" }
+  ]
 }

--- a/packages/connector-i18n-js/package.json
+++ b/packages/connector-i18n-js/package.json
@@ -30,7 +30,7 @@
     "dist/**/*",
     "cjs/**/*",
     "src/**/*",
-    "!src/**/*.test.ts",
+    "!**/*.test.*",
     "!src/__fixtures__/**/*"
   ],
   "type": "module",
@@ -40,16 +40,14 @@
     "default": "./dist/index.js"
   },
   "scripts": {
-    "build": "$npm_execpath run build:esm && $npm_execpath run build:cjs",
-    "build:cjs": "tsc -p tsconfig.build-cjs.json",
-    "build:esm": "tsc -p tsconfig.build.json",
-    "clean": "rimraf dist cjs/dist",
+    "build": "tsc --build",
+    "clean": "rimraf dist cjs/dist '*.tsbuildinfo'",
     "fmt": "yarn workspace root prettier -w ./packages/connector-i18n-js",
     "fmt:check": "yarn workspace root prettier -c ./packages/connector-i18n-js",
     "lint": "yarn workspace root eslint ./packages/connector-i18n-js",
     "prepack": "$npm_execpath run clean && $npm_execpath run build",
     "test": "vitest",
-    "tsc": "tsc"
+    "tsc": "tsc --build"
   },
   "dependencies": {
     "@hi18n/tools-core": "^0.1.6",

--- a/packages/connector-i18n-js/tsconfig.build-cjs.json
+++ b/packages/connector-i18n-js/tsconfig.build-cjs.json
@@ -2,7 +2,16 @@
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "module": "commonjs",
+    "moduleResolution": "node10",
     "outDir": "./cjs/dist",
+    "tsBuildInfoFile": "./tsconfig.build-cjs.tsbuildinfo",
     "verbatimModuleSyntax": false
-  }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.*", "src/__fixtures__/**/*"],
+  "references": [
+    { "path": "../tools-core/tsconfig.build-cjs.json" },
+    { "path": "../core/tsconfig.build-cjs.json" },
+    { "path": "../dev-utils/tsconfig.build-cjs.json" }
+  ]
 }

--- a/packages/connector-i18n-js/tsconfig.build.json
+++ b/packages/connector-i18n-js/tsconfig.build.json
@@ -1,13 +1,14 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "noEmit": false,
     "rootDir": "./src",
-    "outDir": "./dist",
-    "declaration": true,
-    "sourceMap": true,
-    "declarationMap": true
+    "outDir": "./dist"
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["src/__fixtures__/**/*", "**/*.test.ts"]
+  "include": ["src/**/*"],
+  "exclude": ["src/__fixtures__/**/*"],
+  "references": [
+    { "path": "../tools-core/tsconfig.build.json" },
+    { "path": "../core/tsconfig.build.json" },
+    { "path": "../dev-utils/tsconfig.build.json" }
+  ]
 }

--- a/packages/connector-i18n-js/tsconfig.json
+++ b/packages/connector-i18n-js/tsconfig.json
@@ -1,4 +1,11 @@
 {
-  "extends": "../../tsconfig.json",
-  "exclude": ["dist/**/*", "cjs/dist/**/*", "src/__fixtures__/**/*"]
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "exclude": ["dist/**/*", "cjs/dist/**/*", "src/**/*"],
+  "references": [
+    { "path": "./tsconfig.build.json" },
+    { "path": "./tsconfig.build-cjs.json" }
+  ]
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,7 +30,7 @@
     "dist/**/*",
     "cjs/**/*",
     "src/**/*",
-    "!src/**/*.test.ts",
+    "!**/*.test.*",
     "msg.d.ts"
   ],
   "type": "module",
@@ -47,16 +47,14 @@
   },
   "sideEffects": false,
   "scripts": {
-    "build": "$npm_execpath run build:esm && $npm_execpath run build:cjs",
-    "build:cjs": "tsc -p tsconfig.build-cjs.json",
-    "build:esm": "tsc -p tsconfig.build.json",
-    "clean": "rimraf dist cjs/dist",
+    "build": "tsc --build",
+    "clean": "rimraf dist cjs/dist '*.tsbuildinfo'",
     "fmt": "yarn workspace root prettier -w ./packages/core",
     "fmt:check": "yarn workspace root prettier -c ./packages/core",
     "lint": "yarn workspace root eslint ./packages/core",
     "prepack": "$npm_execpath run clean && $npm_execpath run build",
     "test": "vitest",
-    "tsc": "tsc"
+    "tsc": "tsc --build"
   },
   "devDependencies": {
     "rimraf": "^3.0.2",

--- a/packages/core/tsconfig.build-cjs.json
+++ b/packages/core/tsconfig.build-cjs.json
@@ -2,7 +2,11 @@
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "module": "commonjs",
+    "moduleResolution": "node10",
     "outDir": "./cjs/dist",
+    "tsBuildInfoFile": "./tsconfig.build-cjs.tsbuildinfo",
     "verbatimModuleSyntax": false
-  }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.*"]
 }

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -1,13 +1,11 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "noEmit": false,
+    // https://caniuse.com/mdn-javascript_classes_static_initialization_blocks
+    "target": "es2021",
+
     "rootDir": "./src",
-    "outDir": "./dist",
-    "declaration": true,
-    "sourceMap": true,
-    "declarationMap": true
+    "outDir": "./dist"
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["**/*.test.ts"]
+  "include": ["src/**/*"]
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,9 +1,11 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    // https://caniuse.com/mdn-javascript_classes_static_initialization_blocks
-    "target": "es2021",
-    "lib": ["esnext", "dom"]
+    "noEmit": true
   },
-  "exclude": ["dist/**/*", "cjs/dist/**/*"]
+  "exclude": ["dist/**/*", "cjs/dist/**/*", "src/**/*"],
+  "references": [
+    { "path": "./tsconfig.build.json" },
+    { "path": "./tsconfig.build-cjs.json" }
+  ]
 }

--- a/packages/dev-utils/package.json
+++ b/packages/dev-utils/package.json
@@ -31,7 +31,7 @@
     "dist/**/*",
     "cjs/**/*",
     "src/**/*",
-    "!src/**/*.test.ts"
+    "!**/*.test.*"
   ],
   "type": "module",
   "main": "./cjs/dist/index.js",
@@ -40,16 +40,14 @@
     "default": "./dist/index.js"
   },
   "scripts": {
-    "build": "$npm_execpath run build:esm && $npm_execpath run build:cjs",
-    "build:cjs": "tsc -p tsconfig.build-cjs.json",
-    "build:esm": "tsc -p tsconfig.build.json",
-    "clean": "rimraf dist cjs/dist",
+    "build": "tsc --build",
+    "clean": "rimraf dist cjs/dist '*.tsbuildinfo'",
     "fmt": "yarn workspace root prettier -w ./packages/dev-utils",
     "fmt:check": "yarn workspace root prettier -c ./packages/dev-utils",
     "lint": "yarn workspace root eslint ./packages/dev-utils",
     "prepack": "$npm_execpath run clean && $npm_execpath run build",
     "test": "vitest",
-    "tsc": "tsc"
+    "tsc": "tsc --build"
   },
   "dependencies": {
     "commander": "^13.1.0",

--- a/packages/dev-utils/tsconfig.build-cjs.json
+++ b/packages/dev-utils/tsconfig.build-cjs.json
@@ -2,7 +2,11 @@
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "module": "commonjs",
+    "moduleResolution": "node10",
     "outDir": "./cjs/dist",
+    "tsBuildInfoFile": "./tsconfig.build-cjs.tsbuildinfo",
     "verbatimModuleSyntax": false
-  }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.*"]
 }

--- a/packages/dev-utils/tsconfig.build.json
+++ b/packages/dev-utils/tsconfig.build.json
@@ -1,13 +1,8 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "noEmit": false,
     "rootDir": "./src",
-    "outDir": "./dist",
-    "declaration": true,
-    "sourceMap": true,
-    "declarationMap": true
+    "outDir": "./dist"
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["**/*.test.ts"]
+  "include": ["src/**/*"]
 }

--- a/packages/dev-utils/tsconfig.json
+++ b/packages/dev-utils/tsconfig.json
@@ -1,4 +1,11 @@
 {
-  "extends": "../../tsconfig.json",
-  "exclude": ["dist/**/*", "cjs/dist/**/*"]
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "exclude": ["dist/**/*", "cjs/dist/**/*", "src/**/*"],
+  "references": [
+    { "path": "./tsconfig.build.json" },
+    { "path": "./tsconfig.build-cjs.json" }
+  ]
 }

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -32,7 +32,7 @@
     "dist/**/*",
     "cjs/**/*",
     "src/**/*",
-    "!src/**/*.test.ts"
+    "!**/*.test.*"
   ],
   "type": "module",
   "main": "./cjs/wrapper.js",
@@ -47,16 +47,14 @@
     }
   },
   "scripts": {
-    "build": "$npm_execpath run build:esm && $npm_execpath run build:cjs",
-    "build:cjs": "tsc -p tsconfig.build-cjs.json",
-    "build:esm": "tsc -p tsconfig.build.json",
-    "clean": "rimraf dist cjs/dist",
+    "build": "tsc --build",
+    "clean": "rimraf dist cjs/dist '*.tsbuildinfo'",
     "fmt": "yarn workspace root prettier -w ./packages/eslint-plugin",
     "fmt:check": "yarn workspace root prettier -c ./packages/eslint-plugin",
     "lint": "yarn workspace root eslint ./packages/eslint-plugin",
     "prepack": "$npm_execpath run clean && $npm_execpath run build",
     "test": "vitest",
-    "tsc": "tsc"
+    "tsc": "tsc --build"
   },
   "dependencies": {
     "@typescript-eslint/utils": "^8.42.0",

--- a/packages/eslint-plugin/tsconfig.build-cjs.json
+++ b/packages/eslint-plugin/tsconfig.build-cjs.json
@@ -2,7 +2,11 @@
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "module": "commonjs",
+    "moduleResolution": "node10",
     "outDir": "./cjs/dist",
+    "tsBuildInfoFile": "./tsconfig.build-cjs.tsbuildinfo",
     "verbatimModuleSyntax": false
-  }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.*"]
 }

--- a/packages/eslint-plugin/tsconfig.build.json
+++ b/packages/eslint-plugin/tsconfig.build.json
@@ -1,13 +1,8 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "noEmit": false,
     "rootDir": "./src",
-    "outDir": "./dist",
-    "declaration": true,
-    "sourceMap": true,
-    "declarationMap": true
+    "outDir": "./dist"
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["**/*.test.ts"]
+  "include": ["src/**/*"]
 }

--- a/packages/eslint-plugin/tsconfig.json
+++ b/packages/eslint-plugin/tsconfig.json
@@ -1,4 +1,11 @@
 {
-  "extends": "../../tsconfig.json",
-  "exclude": ["dist/**/*", "cjs/dist/**/*"]
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "exclude": ["dist/**/*", "cjs/dist/**/*", "src/**/*"],
+  "references": [
+    { "path": "./tsconfig.build.json" },
+    { "path": "./tsconfig.build-cjs.json" }
+  ]
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -32,8 +32,7 @@
     "dist/**/*",
     "cjs/**/*",
     "src/**/*",
-    "!src/**/*.test.ts",
-    "!src/**/*.test.tsx"
+    "!**/*.test.*"
   ],
   "type": "module",
   "main": "./cjs/dist/index.js",
@@ -43,16 +42,14 @@
   },
   "sideEffects": false,
   "scripts": {
-    "build": "$npm_execpath run build:esm && $npm_execpath run build:cjs",
-    "build:cjs": "tsc -p tsconfig.build-cjs.json",
-    "build:esm": "tsc -p tsconfig.build.json",
-    "clean": "rimraf dist cjs/dist",
+    "build": "tsc --build",
+    "clean": "rimraf dist cjs/dist '*.tsbuildinfo'",
     "fmt": "yarn workspace root prettier -w ./packages/react",
     "fmt:check": "yarn workspace root prettier -c ./packages/react",
     "lint": "yarn workspace root eslint ./packages/react",
     "prepack": "$npm_execpath run clean && $npm_execpath run build",
     "test": "vitest",
-    "tsc": "tsc"
+    "tsc": "tsc --build"
   },
   "dependencies": {
     "@types/react": "^16.8.3 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/packages/react/tsconfig.build-cjs.json
+++ b/packages/react/tsconfig.build-cjs.json
@@ -2,7 +2,12 @@
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "module": "commonjs",
+    "moduleResolution": "node10",
     "outDir": "./cjs/dist",
+    "tsBuildInfoFile": "./tsconfig.build-cjs.tsbuildinfo",
     "verbatimModuleSyntax": false
-  }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.*"],
+  "references": [{ "path": "../core/tsconfig.build-cjs.json" }]
 }

--- a/packages/react/tsconfig.build.json
+++ b/packages/react/tsconfig.build.json
@@ -1,13 +1,12 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "noEmit": false,
+    // https://caniuse.com/mdn-javascript_classes_static_initialization_blocks
+    "target": "es2021",
+
     "rootDir": "./src",
-    "outDir": "./dist",
-    "declaration": true,
-    "sourceMap": true,
-    "declarationMap": true
+    "outDir": "./dist"
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx"],
-  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
+  "include": ["src/**/*"],
+  "references": [{ "path": "../core/tsconfig.build.json" }]
 }

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,9 +1,11 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    // https://caniuse.com/mdn-javascript_classes_static_initialization_blocks
-    "target": "es2021",
-    "lib": ["esnext", "dom"]
+    "noEmit": true
   },
-  "exclude": ["dist/**/*", "cjs/dist/**/*"]
+  "exclude": ["dist/**/*", "cjs/dist/**/*", "src/**/*"],
+  "references": [
+    { "path": "./tsconfig.build.json" },
+    { "path": "./tsconfig.build-cjs.json" }
+  ]
 }

--- a/packages/tools-core/package.json
+++ b/packages/tools-core/package.json
@@ -30,7 +30,7 @@
     "dist/**/*",
     "cjs/**/*",
     "src/**/*",
-    "!src/**/*.test.ts"
+    "!**/*.test.*"
   ],
   "type": "module",
   "main": "./cjs/dist/index.js",
@@ -39,16 +39,14 @@
     "default": "./dist/index.js"
   },
   "scripts": {
-    "build": "$npm_execpath run build:esm && $npm_execpath run build:cjs",
-    "build:cjs": "tsc -p tsconfig.build-cjs.json",
-    "build:esm": "tsc -p tsconfig.build.json",
-    "clean": "rimraf dist cjs/dist",
+    "build": "tsc --build",
+    "clean": "rimraf dist cjs/dist '*.tsbuildinfo'",
     "fmt": "yarn workspace root prettier -w ./packages/tools-core",
     "fmt:check": "yarn workspace root prettier -c ./packages/tools-core",
     "lint": "yarn workspace root eslint ./packages/tools-core",
     "prepack": "$npm_execpath run clean && $npm_execpath run build",
     "test": "vitest",
-    "tsc": "tsc"
+    "tsc": "tsc --build"
   },
   "devDependencies": {
     "rimraf": "^3.0.2",

--- a/packages/tools-core/tsconfig.build-cjs.json
+++ b/packages/tools-core/tsconfig.build-cjs.json
@@ -2,7 +2,11 @@
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "module": "commonjs",
+    "moduleResolution": "node10",
     "outDir": "./cjs/dist",
+    "tsBuildInfoFile": "./tsconfig.build-cjs.tsbuildinfo",
     "verbatimModuleSyntax": false
-  }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.*"]
 }

--- a/packages/tools-core/tsconfig.build.json
+++ b/packages/tools-core/tsconfig.build.json
@@ -1,13 +1,8 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "noEmit": false,
     "rootDir": "./src",
-    "outDir": "./dist",
-    "declaration": true,
-    "sourceMap": true,
-    "declarationMap": true
+    "outDir": "./dist"
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["**/*.test.ts"]
+  "include": ["src/**/*"]
 }

--- a/packages/tools-core/tsconfig.json
+++ b/packages/tools-core/tsconfig.json
@@ -1,4 +1,11 @@
 {
-  "extends": "../../tsconfig.json",
-  "exclude": ["dist/**/*", "cjs/dist/**/*"]
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "exclude": ["dist/**/*", "cjs/dist/**/*", "src/**/*"],
+  "references": [
+    { "path": "./tsconfig.build.json" },
+    { "path": "./tsconfig.build-cjs.json" }
+  ]
 }

--- a/packages/ts-plugin/package.json
+++ b/packages/ts-plugin/package.json
@@ -21,7 +21,7 @@
     "dist/**/*",
     "cjs/**/*",
     "src/**/*",
-    "!src/**/*.test.ts"
+    "!**/*.test.*"
   ],
   "type": "module",
   "main": "./cjs/wrapper.js",
@@ -30,15 +30,13 @@
     "default": "./dist/index.js"
   },
   "scripts": {
-    "build": "$npm_execpath run build:esm && $npm_execpath run build:cjs",
-    "build:cjs": "tsc -p tsconfig.build-cjs.json",
-    "build:esm": "tsc -p tsconfig.build.json",
-    "clean": "rimraf dist cjs/dist",
+    "build": "tsc --build",
+    "clean": "rimraf dist cjs/dist '*.tsbuildinfo'",
     "fmt": "yarn workspace root prettier -w ./packages/ts-plugin",
     "fmt:check": "yarn workspace root prettier -c ./packages/ts-plugin",
     "lint": "yarn workspace root eslint ./packages/ts-plugin",
     "prepack": "$npm_execpath run clean && $npm_execpath run build",
-    "tsc": "tsc"
+    "tsc": "tsc --build"
   },
   "devDependencies": {
     "@types/node": "^22.18.1",

--- a/packages/ts-plugin/tsconfig.build-cjs.json
+++ b/packages/ts-plugin/tsconfig.build-cjs.json
@@ -2,7 +2,11 @@
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "module": "commonjs",
+    "moduleResolution": "node10",
     "outDir": "./cjs/dist",
+    "tsBuildInfoFile": "./tsconfig.build-cjs.tsbuildinfo",
     "verbatimModuleSyntax": false
-  }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.*"]
 }

--- a/packages/ts-plugin/tsconfig.build.json
+++ b/packages/ts-plugin/tsconfig.build.json
@@ -1,13 +1,8 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "noEmit": false,
     "rootDir": "./src",
-    "outDir": "./dist",
-    "declaration": true,
-    "sourceMap": true,
-    "declarationMap": true
+    "outDir": "./dist"
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["**/*.test.ts"]
+  "include": ["src/**/*"]
 }

--- a/packages/ts-plugin/tsconfig.json
+++ b/packages/ts-plugin/tsconfig.json
@@ -1,4 +1,11 @@
 {
-  "extends": "../../tsconfig.json",
-  "exclude": ["dist/**/*", "cjs/dist/**/*"]
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "exclude": ["dist/**/*", "cjs/dist/**/*", "src/**/*"],
+  "references": [
+    { "path": "./tsconfig.build.json" },
+    { "path": "./tsconfig.build-cjs.json" }
+  ]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,32 @@
+{
+  "compilerOptions": {
+    "target": "es2024",
+    "lib": ["es2024", "dom"],
+    "useDefineForClassFields": true,
+    "module": "node20",
+    "moduleResolution": "node16",
+    "jsx": "react-jsx",
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "noUncheckedSideEffectImports": true,
+
+    "composite": true,
+    "noEmit": false,
+    "declaration": true,
+    "sourceMap": true,
+    "declarationMap": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "isolatedDeclarations": true,
+    "erasableSyntaxOnly": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+
+    "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+
+    "skipLibCheck": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,27 +1,25 @@
 {
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "target": "esnext",
-    "useDefineForClassFields": true,
-    "module": "nodenext",
-    "jsx": "react-jsx",
-    "allowImportingTsExtensions": true,
-    "rewriteRelativeImportExtensions": true,
-    "noUncheckedSideEffectImports": true,
-
-    "noEmit": true,
-    "declaration": true,
-    "isolatedModules": true,
-    "verbatimModuleSyntax": true,
-    "isolatedDeclarations": true,
-    "erasableSyntaxOnly": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-
-    "strict": true,
-    "exactOptionalPropertyTypes": true,
-    "noUncheckedIndexedAccess": true,
-    "noImplicitOverride": true,
-
-    "skipLibCheck": true
-  }
+    "noEmit": true
+  },
+  "references": [
+    { "path": "./packages/core/tsconfig.build.json" },
+    { "path": "./packages/core/tsconfig.build-cjs.json" },
+    { "path": "./packages/react/tsconfig.build.json" },
+    { "path": "./packages/react/tsconfig.build-cjs.json" },
+    { "path": "./packages/eslint-plugin/tsconfig.build.json" },
+    { "path": "./packages/eslint-plugin/tsconfig.build-cjs.json" },
+    { "path": "./packages/dev-utils/tsconfig.build.json" },
+    { "path": "./packages/dev-utils/tsconfig.build-cjs.json" },
+    { "path": "./packages/tools-core/tsconfig.build.json" },
+    { "path": "./packages/tools-core/tsconfig.build-cjs.json" },
+    { "path": "./packages/cli/tsconfig.build.json" },
+    { "path": "./packages/cli/tsconfig.build-cjs.json" },
+    { "path": "./packages/connector-i18n-js/tsconfig.build.json" },
+    { "path": "./packages/connector-i18n-js/tsconfig.build-cjs.json" },
+    { "path": "./packages/ts-plugin/tsconfig.build.json" },
+    { "path": "./packages/ts-plugin/tsconfig.build-cjs.json" }
+  ],
+  "exclude": ["packages/*/dist/**/*", "packages/*/src"]
 }


### PR DESCRIPTION
## Why

In a monorepo, it is important that the dependencies in the workspace are properly built before building, testing, or linting a package.

The "references" field in tsconfig is suited in this situation because it allows:

- building the only necessary dependencies, and
- using tsbuildinfo to skip the unnecessary build.

## What

Migrate to the "references" set up in tsconfig.

In fact, we had used "references" before but once [migrated away from that](https://github.com/wantedly/hi18n/pull/203). These days we had different projects for `src/*.ts` and `src/*.test.ts` sources, but it introduced a problem: with TypeScript-ESLint, when `src/*.ts` files are updated, the changes in type information do not propagate to lint results for `src/*.test.ts` files.

We fixed this problem by building `src/*.ts` and `src/*.test.ts` files altogether in one project, and then exclude the latter files in the `"files":` field in package.json.

Bumping all the affected packages because it changes how files are published. There are no expected change in behaviors.