### PR TITLE
chore(cli): clarify we publish bin files

### DIFF
--- a/.changeset/loud-bears-obey.md
+++ b/.changeset/loud-bears-obey.md
@@ -1,0 +1,5 @@
+---
+"@hi18n/cli": patch
+---
+
+chore(cli): clarify we publish bin files

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -170,13 +170,6 @@ export default defineConfig([
     },
   },
   {
-    files: ["**/bin/hi18n.cjs"],
-    rules: {
-      // Ignoring it for now
-      "n/no-unpublished-bin": "off",
-    },
-  },
-  {
     extends: [eslintConfigPrettier],
   },
 ]);

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,6 +27,7 @@
   "author": "Masaki Hara <ackie.h.gmai@gmail.com>",
   "license": "MIT",
   "files": [
+    "bin/hi18n.cjs",
     "dist/**/*",
     "cjs/**/*",
     "src/**/*",


### PR DESCRIPTION
## Why

It is the best opportunity to publish slight changes in `files` when https://github.com/wantedly/hi18n/pull/260 is going to be published.

Although I suppose `bin/*` are already included for some reason, it is best that we clarify their inclusion.

## What

Clarify that we publish `bin/*` files.