### PR TITLE
Add minimumReleaseAge for supply chain protection

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,7 @@
 {
   "extends": ["config:base"],
+  "minimumReleaseAge": "7 days",
+  "internalChecksFilter": "strict",
   "postUpdateOptions": ["yarnDedupeHighest"],
   "packageRules": [
     {


### PR DESCRIPTION
## Why

Supply chain attacks through compromised npm packages have become increasingly common. Adding a cooldown period before Renovate creates PRs for new releases gives the community time to detect and report malicious packages.

## What

Add `minimumReleaseAge: "7 days"` and `internalChecksFilter: "strict"` to `renovate.json`. This delays Renovate PR creation for 7 days after a new version is published, while vulnerability alerts bypass this delay.