### PR TITLE
Disable Yarn install scripts by default with enableScripts: false

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,5 @@
+enableScripts: false
+
 compressionLevel: mixed
 
 enableGlobalCache: false

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,6 @@
+# 依存パッケージの install script 経由サプライチェーン攻撃対策としてデフォルト無効化。
+# 個別に許可する場合は package.json の dependenciesMeta で `"built": true` を指定する。
+# refs: https://github.com/wantedly/infrastructure/issues/15382
 enableScripts: false
 
 compressionLevel: mixed

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,6 +1,5 @@
-# 依存パッケージの install script 経由サプライチェーン攻撃対策としてデフォルト無効化。
-# 個別に許可する場合は package.json の dependenciesMeta で `"built": true` を指定する。
-# refs: https://github.com/wantedly/infrastructure/issues/15382
+# Disabled by default to prevent supply chain attacks via install scripts.
+# To allow a specific package, set `"built": true` in dependenciesMeta of package.json.
 enableScripts: false
 
 compressionLevel: mixed

--- a/package.json
+++ b/package.json
@@ -41,5 +41,10 @@
   "resolutions": {
     "pretty-format/react-is": "^19.0.0",
     "eslint-visitor-keys@npm:^3.3.0": "patch:eslint-visitor-keys@npm%3A3.3.0#~/.yarn/patches/eslint-visitor-keys-npm-3.3.0-d329af7c8c.patch"
+  },
+  "dependenciesMeta": {
+    "esbuild": {
+      "built": true
+    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5191,6 +5191,9 @@ __metadata:
     typescript: "npm:^5.9.2"
     typescript-eslint: "npm:^8.42.0"
     vitest: "npm:^3.2.4"
+  dependenciesMeta:
+    esbuild:
+      built: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## WHY

As part of supply-chain-attack mitigation, disable Yarn install scripts by default so that only vetted packages can run build hooks. This complements the existing `npmMinimalAgeGate` / `npmPreapprovedPackages` settings and is being rolled out across multiple Wantedly repositories.

## WHAT

- Add `enableScripts: false` to `.yarnrc.yml`
- Allow `esbuild` to run its build hook via `dependenciesMeta` in `package.json`
  - esbuild installs a native binary via its postinstall hook
- `yarn.lock` is updated only to reflect the new `dependenciesMeta` field on the workspace entry; no package versions changed

### Verification

- `yarn install` completes successfully and esbuild is built as expected
- Remaining unbuilt warnings are for packages intentionally excluded from the allow list (dd-trace, protobufjs, @datadog/native-*, etc.) whose hooks are non-essential

🤖 Generated with [Claude Code](https://claude.com/claude-code)